### PR TITLE
convert all times to gmt

### DIFF
--- a/test/services/R2DateConverterSpec.scala
+++ b/test/services/R2DateConverterSpec.scala
@@ -1,0 +1,21 @@
+package services.migration
+
+import org.specs2.mutable.Specification
+
+
+class R2DateConverterSpec extends Specification  {
+
+  "R2DateConverter" should {
+    "convert BST times into GMT" in {
+      val bstTime = "2007-10-24T11:48:10.000+01:00"
+      val xmlDate = R2DateConversion.jsonToXmlDateTime(bstTime)
+      xmlDate must equalTo("200710241048")
+    }
+    "leave GMT times alone" in {
+      val bstTime = "2007-02-22T17:39:39.000Z"
+      val xmlDate = R2DateConversion.jsonToXmlDateTime(bstTime)
+      xmlDate must equalTo("200702221739")
+    }
+  }
+
+}

--- a/test/services/migration/R2CmsPathCleanerSpec.scala
+++ b/test/services/migration/R2CmsPathCleanerSpec.scala
@@ -1,9 +1,6 @@
 package services.migration
 
-import R2CMSPathCleaner._
-
 import org.specs2.mutable.Specification
-
 
 class R2CMSPathCleanerSpec extends Specification  {
 


### PR DESCRIPTION
Certain times are gaining an hour when migrating. This is because BST is being migrated without a timezone, and flex is assuming it is GMT
Soln is to migrate all times as GMT