### PR TITLE
rights migration: map r2 default values correctly

### DIFF
--- a/app/services/migration/R2ToFlexConversion.scala
+++ b/app/services/migration/R2ToFlexConversion.scala
@@ -139,9 +139,18 @@ abstract class R2ToFlexContentConversion(jsonMap : Map[String, Any], parseLiveDa
     }}
   }
 
-  protected def syndicationAggregateFn = getAsString("syndicationAggregate")
-  protected def subscriptionDatabasesFn = getAsString("subscriptionDatabases")
-  protected def developerCommunityFn = getAsString("developerCommunity")
+  private def mapRights(rightValue : Option[String]) = {
+    //historical videos can have null values in the DB - CAPI api-indexer will default to 'true', migrated content should
+    //keep the same behaviour
+    rightValue match {
+      case None => Some("true")
+      case Some(x) => Some(x)
+    }
+  }
+
+  protected def syndicationAggregateFn = mapRights(getAsString("syndicationAggregate"))
+  protected def subscriptionDatabasesFn = mapRights(getAsString("subscriptionDatabases"))
+  protected def developerCommunityFn = mapRights(getAsString("developerCommunity"))
 
   type ExpiryInfo = (Option[Boolean], Option[String], Option[String])
   protected def getRightsExpiry : Option[ExpiryInfo] = {

--- a/test/resources/migration/r2Gallery2.json
+++ b/test/resources/migration/r2Gallery2.json
@@ -1,0 +1,2249 @@
+{
+  "draft": {
+    "pictures": [
+      {
+        "caption": "A butterfly by the Palm House at Bicton Park Botanical Gardens",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563703,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/garden1-1373.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "A butterfly by the Palm House at Bicton Park Botanical Gardens",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:41.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563704,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/garden1-1373-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "A butterfly by the Palm House at Bicton Park Botanical Gardens",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:42.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563705
+      },
+      {
+        "caption": "A hellebore at Docton Mill Gardens (Helleborus 'Harvington Smokey Blues')",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563706,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens14-2052.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "A hellebore at Docton Mill Gardens (Helleborus 'Harvington Smokey Blues')",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:42.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563707,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens14-2052-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "A hellebore at Docton Mill Gardens (Helleborus 'Harvington Smokey Blues')",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:42.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563708
+      },
+      {
+        "caption": "Sea Holly at Bourton House Garden",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563709,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens11-2437.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Sea Holly at Bourton House Garden",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:42.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563710,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens11-2437-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Sea Holly at Bourton House Garden",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:42.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563711
+      },
+      {
+        "caption": "Camelias at Fast Rabbit Garden, Devon",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563712,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/garden3-2880.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Camelias at Fast Rabbit Garden, Devon",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:43.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563713,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/garden3-2880-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Camelias at Fast Rabbit Garden, Devon",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:43.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563714
+      },
+      {
+        "caption": " English Ivy at Painswick Rococo Garden",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563715,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/garden2-3274.jpg",
+          "mimeType": "image/jpeg",
+          "caption": " English Ivy at Painswick Rococo Garden",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:43.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563716,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/garden2-3274-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": " English Ivy at Painswick Rococo Garden",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:43.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563717
+      },
+      {
+        "caption": "Wildflower meadow at Pencarrow, Cornwall",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563718,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens1-3675.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Wildflower meadow at Pencarrow, Cornwall",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:43.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563719,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens1-3675-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Wildflower meadow at Pencarrow, Cornwall",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:44.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563720
+      },
+      {
+        "caption": "Autumn colour at Westonbirt, the National Arboretum",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563721,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens10-4102.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Autumn colour at Westonbirt, the National Arboretum",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:44.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563722,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens10-4102-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Autumn colour at Westonbirt, the National Arboretum",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:44.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563723
+      },
+      {
+        "caption": "Bluebells and Japanese Maples at Westonbirt",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563724,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens12-4517.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Bluebells and Japanese Maples at Westonbirt",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:44.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563725,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens12-4517-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Bluebells and Japanese Maples at Westonbirt",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:44.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563726
+      },
+      {
+        "caption": "Clipping the topiary at Bourton House Garden",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563727,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens13-4925.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Clipping the topiary at Bourton House Garden",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:45.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563728,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens13-4925-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Clipping the topiary at Bourton House Garden",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:45.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563729
+      },
+      {
+        "caption": "Magnolia campbellii at Trebah Garden, Cornwall",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563730,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens15-5347.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Magnolia campbellii at Trebah Garden, Cornwall",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:45.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563731,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens15-5347-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Magnolia campbellii at Trebah Garden, Cornwall",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:45.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563732
+      },
+      {
+        "caption": "An inquisitive fox cub at Westonbirt, the National Arboretum",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563733,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens16-5775.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "An inquisitive fox cub at Westonbirt, the National Arboretum",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:45.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563734,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens16-5775-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "An inquisitive fox cub at Westonbirt, the National Arboretum",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:46.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563735
+      },
+      {
+        "caption": "The blue poppy at Abbey House Gardens, Wiltshire",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563739,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens18-6580.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "The blue poppy at Abbey House Gardens, Wiltshire",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:46.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563740,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens18-6580-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "The blue poppy at Abbey House Gardens, Wiltshire",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:46.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563741
+      },
+      {
+        "caption": "Cothay Manor Gardens",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563742,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens21-6985.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Cothay Manor Gardens",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:47.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563743,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens21-6985-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Cothay Manor Gardens",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:47.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563744
+      },
+      {
+        "caption": "Tulips at Abbey House Gardens, Wiltshire",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563745,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens5-7411.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Tulips at Abbey House Gardens, Wiltshire",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:47.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563746,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens5-7411-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Tulips at Abbey House Gardens, Wiltshire",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:47.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563747
+      },
+      {
+        "caption": "Astrantia at Abbey House Gardens, Wiltshire",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563748,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens8-7810.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Astrantia at Abbey House Gardens, Wiltshire",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:48.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563749,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens8-7810-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Astrantia at Abbey House Gardens, Wiltshire",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:48.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563750
+      },
+      {
+        "caption": "Common frog at Cothay Manor",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563751,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens9-8214.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Common frog at Cothay Manor",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:48.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563752,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens9-8214-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Common frog at Cothay Manor",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:48.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563753
+      },
+      {
+        "caption": "Dear at Prideaux Place in Cornwall - purportedly the oldest deer park in the country",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563754,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens6-8592.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Dear at Prideaux Place in Cornwall - purportedly the oldest deer park in the country",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:48.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563755,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens6-8592-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Dear at Prideaux Place in Cornwall - purportedly the oldest deer park in the country",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:49.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563756
+      },
+      {
+        "caption": "Cosmos flower at the Abbey Garden on Tresco",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563757,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens22-9007.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Cosmos flower at the Abbey Garden on Tresco",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:49.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563758,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens22-9007-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Cosmos flower at the Abbey Garden on Tresco",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:49.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563759
+      },
+      {
+        "caption": "Very exclusive honey produced from an array of exotic plants at the Abbey Garden, Tresco",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563763,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens20-9805.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Very exclusive honey produced from an array of exotic plants at the Abbey Garden, Tresco",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:50.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563764,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens20-9805-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Very exclusive honey produced from an array of exotic plants at the Abbey Garden, Tresco",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:50.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563765
+      },
+      {
+        "caption": "Corkscrew hazel at Stourton House Flower Garden",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563766,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens4-192.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Corkscrew hazel at Stourton House Flower Garden",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:50.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563767,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens4-192-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Corkscrew hazel at Stourton House Flower Garden",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:50.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563768
+      },
+      {
+        "caption": "The exotic Abbey Garden on Tresco, Isles of Scilly",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563769,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens7-634.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "The exotic Abbey Garden on Tresco, Isles of Scilly",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:50.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563770,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens7-634-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "The exotic Abbey Garden on Tresco, Isles of Scilly",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:51.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563771
+      }
+    ],
+    "creationAndLastModifiedDetail": {
+      "createdOn": "2015-10-16T11:18:38.956+01:00",
+      "modifiedOn": "2015-10-16T11:18:38.956+01:00"
+    },
+    "factboxes": [],
+    "platformPictures": [],
+    "publishOnCom": false,
+    "tags": [
+      12501,
+      13141,
+      29638,
+      26904,
+      4
+    ],
+    "editorial": true,
+    "publicationDate": "2007-08-14T00:00:00.000+01:00",
+    "webPublicationDateTime": "2007-08-14T13:30:27.000+01:00",
+    "updateWebPublicationDateTimeOnLaunch": false,
+    "relatedEditorialOff": false,
+    "pages": [
+      {
+        "id": 229861,
+        "readyToLive": false,
+        "badgesOff": false,
+        "trailText": "<b>In pictures:</b> A photo essay of beautiful gardens in the south-west forms part of a new project to encourage us all to visit our local treasures throughout the year.",
+        "linkText": "The heart of a garden",
+        "isExternalRss": false,
+        "isBlockAds": false,
+        "defaultTrailPictureMediaId": "gu-image-330566530",
+        "defaultTrailPictureImgId": 330565452,
+        "largeTrailPictureMediaId": "gu-image-330566530",
+        "largeTrailPictureImgId": 330565452,
+        "cmsPath": {
+          "path": "/Guardian/lifeandhealth/gallery/2007/aug/14/gardens.wildlife"
+        },
+        "seciton": 196,
+        "createdBy": "Travel Editor",
+        "lastModifiedBy": "Travel Editor",
+        "createdOn": "2007-08-14T09:29:51.000+01:00",
+        "modifiedOn": "2007-08-14T13:30:14.000+01:00",
+        "lastLiveTime": "2007-08-14T13:30:27.000+01:00",
+        "webPublicationTime": "2007-08-14T13:30:27.000+01:00",
+        "launchableTemplate": {
+          "displayName": "Gallery",
+          "staticName": "Gallery",
+          "location": "templates/common/gallery",
+          "stylesheetName": "gallery-grid",
+          "pageTypes": [
+            "GALLERY"
+          ],
+          "templateCode": 23,
+          "shownInTemplateDropDown": true,
+          "coreContentAreaName": {
+            "name": "gallery"
+          },
+          "id": 83
+        }
+      }
+    ],
+    "trailblock": {},
+    "pluckCommentable": false,
+    "pluckPremoderated": false,
+    "synchronisedWithPluck": false,
+    "externalReferences": [],
+    "expired": false,
+    "automateLinking": false,
+    "sensitive": false,
+    "blockAds": false,
+    "headline": "The heart of a garden",
+    "standfirst": "The Heart of a Garden is a new film and book project celebrating 16 beautiful gardens from the south-west, all of which are open to the public. Further books will cover the whole of the UK and Ireland. The authors - who are self-professed garden amateurs - hope that the pictures will encourage us to visit more gardens, not just in summer but throughout the year. \r\n<br><br>\r\nMore information at <a href=\"http://www.theheartofagarden.com\">www.theheartofagarden.com</a>",
+    "id": 330563772
+  },
+  "live": {
+    "pictures": [
+      {
+        "caption": "A butterfly by the Palm House at Bicton Park Botanical Gardens",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563703,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/garden1-1373.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "A butterfly by the Palm House at Bicton Park Botanical Gardens",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:41.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563704,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/garden1-1373-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "A butterfly by the Palm House at Bicton Park Botanical Gardens",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:42.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563705
+      },
+      {
+        "caption": "A hellebore at Docton Mill Gardens (Helleborus 'Harvington Smokey Blues')",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563706,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens14-2052.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "A hellebore at Docton Mill Gardens (Helleborus 'Harvington Smokey Blues')",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:42.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563707,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens14-2052-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "A hellebore at Docton Mill Gardens (Helleborus 'Harvington Smokey Blues')",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:42.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563708
+      },
+      {
+        "caption": "Sea Holly at Bourton House Garden",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563709,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens11-2437.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Sea Holly at Bourton House Garden",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:42.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563710,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens11-2437-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Sea Holly at Bourton House Garden",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:42.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563711
+      },
+      {
+        "caption": "Camelias at Fast Rabbit Garden, Devon",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563712,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/garden3-2880.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Camelias at Fast Rabbit Garden, Devon",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:43.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563713,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/garden3-2880-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Camelias at Fast Rabbit Garden, Devon",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:43.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563714
+      },
+      {
+        "caption": " English Ivy at Painswick Rococo Garden",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563715,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/garden2-3274.jpg",
+          "mimeType": "image/jpeg",
+          "caption": " English Ivy at Painswick Rococo Garden",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:43.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563716,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/garden2-3274-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": " English Ivy at Painswick Rococo Garden",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:43.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563717
+      },
+      {
+        "caption": "Wildflower meadow at Pencarrow, Cornwall",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563718,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens1-3675.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Wildflower meadow at Pencarrow, Cornwall",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:43.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563719,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens1-3675-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Wildflower meadow at Pencarrow, Cornwall",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:44.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563720
+      },
+      {
+        "caption": "Autumn colour at Westonbirt, the National Arboretum",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563721,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens10-4102.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Autumn colour at Westonbirt, the National Arboretum",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:44.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563722,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens10-4102-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Autumn colour at Westonbirt, the National Arboretum",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:44.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563723
+      },
+      {
+        "caption": "Bluebells and Japanese Maples at Westonbirt",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563724,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens12-4517.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Bluebells and Japanese Maples at Westonbirt",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:44.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563725,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens12-4517-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Bluebells and Japanese Maples at Westonbirt",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:44.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563726
+      },
+      {
+        "caption": "Clipping the topiary at Bourton House Garden",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563727,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens13-4925.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Clipping the topiary at Bourton House Garden",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:45.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563728,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens13-4925-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Clipping the topiary at Bourton House Garden",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:45.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563729
+      },
+      {
+        "caption": "Magnolia campbellii at Trebah Garden, Cornwall",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563730,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens15-5347.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Magnolia campbellii at Trebah Garden, Cornwall",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:45.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563731,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens15-5347-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Magnolia campbellii at Trebah Garden, Cornwall",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:45.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563732
+      },
+      {
+        "caption": "An inquisitive fox cub at Westonbirt, the National Arboretum",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563733,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens16-5775.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "An inquisitive fox cub at Westonbirt, the National Arboretum",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:45.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563734,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens16-5775-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "An inquisitive fox cub at Westonbirt, the National Arboretum",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:46.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563735
+      },
+      {
+        "caption": "The blue poppy at Abbey House Gardens, Wiltshire",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563739,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens18-6580.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "The blue poppy at Abbey House Gardens, Wiltshire",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:46.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563740,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens18-6580-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "The blue poppy at Abbey House Gardens, Wiltshire",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:46.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563741
+      },
+      {
+        "caption": "Cothay Manor Gardens",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563742,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens21-6985.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Cothay Manor Gardens",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:47.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563743,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens21-6985-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Cothay Manor Gardens",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:47.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563744
+      },
+      {
+        "caption": "Tulips at Abbey House Gardens, Wiltshire",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563745,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens5-7411.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Tulips at Abbey House Gardens, Wiltshire",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:47.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563746,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens5-7411-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Tulips at Abbey House Gardens, Wiltshire",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:47.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563747
+      },
+      {
+        "caption": "Astrantia at Abbey House Gardens, Wiltshire",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563748,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens8-7810.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Astrantia at Abbey House Gardens, Wiltshire",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:48.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563749,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens8-7810-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Astrantia at Abbey House Gardens, Wiltshire",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:48.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563750
+      },
+      {
+        "caption": "Common frog at Cothay Manor",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563751,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens9-8214.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Common frog at Cothay Manor",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:48.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563752,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens9-8214-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Common frog at Cothay Manor",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:48.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563753
+      },
+      {
+        "caption": "Dear at Prideaux Place in Cornwall - purportedly the oldest deer park in the country",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563754,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens6-8592.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Dear at Prideaux Place in Cornwall - purportedly the oldest deer park in the country",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:48.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563755,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens6-8592-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Dear at Prideaux Place in Cornwall - purportedly the oldest deer park in the country",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:49.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563756
+      },
+      {
+        "caption": "Cosmos flower at the Abbey Garden on Tresco",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563757,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens22-9007.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Cosmos flower at the Abbey Garden on Tresco",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:49.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563758,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens22-9007-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Cosmos flower at the Abbey Garden on Tresco",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:49.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563759
+      },
+      {
+        "caption": "Very exclusive honey produced from an array of exotic plants at the Abbey Garden, Tresco",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563763,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens20-9805.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Very exclusive honey produced from an array of exotic plants at the Abbey Garden, Tresco",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:50.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563764,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens20-9805-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Very exclusive honey produced from an array of exotic plants at the Abbey Garden, Tresco",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:50.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563765
+      },
+      {
+        "caption": "Corkscrew hazel at Stourton House Flower Garden",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563766,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens4-192.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Corkscrew hazel at Stourton House Flower Garden",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:50.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563767,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens4-192-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "Corkscrew hazel at Stourton House Flower Garden",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:50.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563768
+      },
+      {
+        "caption": "The exotic Abbey Garden on Tresco, Isles of Scilly",
+        "altText": "Heart of a garden",
+        "image": {
+          "$type": "image",
+          "id": 330563769,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens7-634.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "The exotic Abbey Garden on Tresco, Isles of Scilly",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 630,
+          "height": 390,
+          "uploadDate": "2007-08-14T09:29:50.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "thumbnailImage": {
+          "$type": "image",
+          "id": 330563770,
+          "url": "http://static.guimcode.co.uk/Guardian/lifeandhealth/gallery/2007/aug/14/gardens/gardens7-634-thumb.jpg",
+          "mimeType": "image/jpeg",
+          "caption": "The exotic Abbey Garden on Tresco, Isles of Scilly",
+          "source": "Oscha",
+          "altText": "Heart of a garden",
+          "width": 68,
+          "height": 68,
+          "uploadDate": "2007-08-14T09:29:51.000+01:00",
+          "group": {
+            "$type": "image_group",
+            "name": "Gallery Images",
+            "legacySection": {
+              "$type": "legacy_section",
+              "name": "Pix",
+              "displayName": "Pix",
+              "siteName": "Guardian"
+            }
+          }
+        },
+        "credit": "Oscha",
+        "id": 330563771
+      }
+    ],
+    "lastLiveTime": "2007-08-14T13:30:27.000+01:00",
+    "factboxes": [],
+    "platformPictures": [],
+    "tags": [
+      12501,
+      13141,
+      29638,
+      26904,
+      4
+    ],
+    "editorial": true,
+    "publicationDate": "2007-08-14T00:00:00.000+01:00",
+    "webPublicationDateTime": "2007-08-14T13:30:27.000+01:00",
+    "updateWebPublicationDateTimeOnLaunch": false,
+    "relatedEditorialOff": false,
+    "pages": [
+      {
+        "id": 229861,
+        "readyToLive": false,
+        "badgesOff": false,
+        "trailText": "<b>In pictures:</b> A photo essay of beautiful gardens in the south-west forms part of a new project to encourage us all to visit our local treasures throughout the year.",
+        "linkText": "The heart of a garden",
+        "isExternalRss": false,
+        "isBlockAds": false,
+        "defaultTrailPictureMediaId": "gu-image-330566530",
+        "defaultTrailPictureImgId": 330565452,
+        "largeTrailPictureMediaId": "gu-image-330566530",
+        "largeTrailPictureImgId": 330565452,
+        "cmsPath": {
+          "path": "/Guardian/lifeandhealth/gallery/2007/aug/14/gardens.wildlife"
+        },
+        "seciton": 196,
+        "createdBy": "Travel Editor",
+        "lastModifiedBy": "Travel Editor",
+        "createdOn": "2007-08-14T09:29:51.000+01:00",
+        "modifiedOn": "2007-08-14T13:30:14.000+01:00",
+        "lastLiveTime": "2007-08-14T13:30:27.000+01:00",
+        "webPublicationTime": "2007-08-14T13:30:27.000+01:00",
+        "launchableTemplate": {
+          "displayName": "Gallery",
+          "staticName": "Gallery",
+          "location": "templates/common/gallery",
+          "stylesheetName": "gallery-grid",
+          "pageTypes": [
+            "GALLERY"
+          ],
+          "templateCode": 23,
+          "shownInTemplateDropDown": true,
+          "coreContentAreaName": {
+            "name": "gallery"
+          },
+          "id": 83
+        }
+      }
+    ],
+    "trailblock": {},
+    "pluckCommentable": false,
+    "pluckPremoderated": false,
+    "synchronisedWithPluck": false,
+    "externalReferences": [],
+    "expired": false,
+    "automateLinking": false,
+    "sensitive": false,
+    "blockAds": false,
+    "headline": "The heart of a garden",
+    "standfirst": "The Heart of a Garden is a new film and book project celebrating 16 beautiful gardens from the south-west, all of which are open to the public. Further books will cover the whole of the UK and Ireland. The authors - who are self-professed garden amateurs - hope that the pictures will encourage us to visit more gardens, not just in summer but throughout the year. \r\n<br><br>\r\nMore information at <a href=\"http://www.theheartofagarden.com\">www.theheartofagarden.com</a>",
+    "productionOffice": "UK",
+    "id": 330563772
+  }
+}

--- a/test/services/migration/R2ToFlexConversionSpec.scala
+++ b/test/services/migration/R2ToFlexConversionSpec.scala
@@ -13,6 +13,7 @@ class R2ToFlexConversionSpec extends Specification  {
       R2ToFlexGalleryConversion.jsonMap(fileAsString)
     }
 
+
     lazy val parsedGalleryJson = R2ToFlexGalleryConversion.parseDraftData(r2Json())
 
     "accept R2 json" in {
@@ -122,6 +123,15 @@ class R2ToFlexConversionSpec extends Specification  {
       val developerCommunity    = (parsedGalleryJson.xml \ "rights" \ "@developerCommunity").headOption.map(_.text.toString.toBoolean)
       syndicationAggregate must equalTo(Some(false))
       subscriptionDatabases must equalTo(Some(false))
+      developerCommunity must equalTo(Some(true))
+    }
+    "parse rights correctly when not present" in {
+      val parsedGalleryJson = R2ToFlexGalleryConversion.parseDraftData(r2Json("/migration/r2Gallery2.json"))
+      val syndicationAggregate  = (parsedGalleryJson.xml \ "rights" \ "@syndicationAggregate").headOption.map(_.text.toString.toBoolean)
+      val subscriptionDatabases = (parsedGalleryJson.xml \ "rights" \ "@subscriptionDatabases").headOption.map(_.text.toString.toBoolean)
+      val developerCommunity    = (parsedGalleryJson.xml \ "rights" \ "@developerCommunity").headOption.map(_.text.toString.toBoolean)
+      syndicationAggregate must equalTo(Some(true))
+      subscriptionDatabases must equalTo(Some(true))
       developerCommunity must equalTo(Some(true))
     }
     "parse rights expiry correctly" in {
@@ -250,9 +260,9 @@ class R2ToFlexConversionSpec extends Specification  {
       val syndicationAggregate  = (parsedCartoonJson.xml \ "rights" \ "@syndicationAggregate").headOption.map(_.text.toString.toBoolean)
       val subscriptionDatabases = (parsedCartoonJson.xml \ "rights" \ "@subscriptionDatabases").headOption.map(_.text.toString.toBoolean)
       val developerCommunity    = (parsedCartoonJson.xml \ "rights" \ "@developerCommunity").headOption.map(_.text.toString.toBoolean)
-      syndicationAggregate must equalTo(None)
-      subscriptionDatabases must equalTo(None)
-      developerCommunity must equalTo(None)
+      syndicationAggregate must equalTo(Some(true))
+      subscriptionDatabases must equalTo(Some(true))
+      developerCommunity must equalTo(Some(true))
     }
     "parse rights expiry correctly" in {
       val isExpired = (parsedCartoonJson.xml \ "expiry" \ "rights" \ "@expired").headOption.map(_.text.toString)


### PR DESCRIPTION
API indexer defaults to true for null rights in R2
Now that Flex is taking the rights, we need to feed this default value into Flex in the same way