### PR TITLE
fields not being sent with article migration

### DIFF
--- a/test/resources/migration/r2article2.json
+++ b/test/resources/migration/r2article2.json
@@ -1,0 +1,172 @@
+{
+  "draft": {
+    "raw": false,
+    "contentBody": {
+      "bodyText": "<p>This week, the TUC took a rare decision to campaign to sack someone.</p><p>The conference, which normally fights to the last man and woman for anybody in a job, took the view that Joel Edwards, commissioner to the Equality and Human Rights Commission, should be <a href=\"http://www.pinknews.co.uk/news/articles/2005-8933.html\">shown the door</a> immediately.</p><p>Edwards is the commissioner, but he is also general director of the <a href=\"http://www.eauk.org/about/whos-who.cfm\">Evangelical Alliance</a> (EA), a fundamentalist Christian group. </p><p>Under his direction, the EA describes gay relationships as sinful and \"a behaviour choice\" and that \"homosexual practice is morally wrong\". His appointment by Ruth Kelly, when she was equalities minister, attracted harsh publicity at the time. But after six months in office, the anger has increased. It boiled over last night at the TUC's lesbian, gay, bisexual and transgender (LGBT) fringe meeting, where a commission official was given the unenviable task of trying to defend Edwards to a polite but hostile audience. He failed.</p><p>I am behind the TUC on this one. What on earth was Trevor Phillips doing, agreeing to allow the government to appoint someone who thinks being gay is some form of undesirable behaviour choice? What will he sanction next? How about appointing a commissioner for race relations from the South African Dutch Reformed Church who might believe that blacks are inferior to whites and can cite the Bible on this?</p><p>The response from the commissioner's office was pathetic. Evidently, Trevor Phillips, its head, is such a frightened rabbit that he daren't say anything to Harriet Harman, the current equalities minister, about it. In a typical buck-passing, bureaucratic moment, press officials passed it to the <a href=\"http://www.equalities.gov.uk/\">Equalities Office</a>, saying they were powerless over the appointment process. What piffle – if they were unhappy, they could do something.</p><p>And the present position is insulting for thousands of gay people – not least among them some of Harriet Harman's gay friends such as Angela Eagle, the Treasury minister and her partner, Maria Exall, chair of the TUC LGBT group and TUC council member. It's bizarre to consider that a man at the head of the commission thinks influential Tory blogger Iain Dale, Conservative frontbencher Alan Duncan and health minister Ben Bradshaw are in sinful relationships which are an unfortunate behaviour choice. No doubt in true Bibical terms, he will treat them as \"lost sheep\" that can be rounded up and repent of their sins.</p><p>Yesterday, Harriet Harman turned the private decision of Maria Exall and Angela Eagle to join a civil partnership into a government announcement when she <a href=\"http://www.mailonsunday.co.uk/news/article-1054339/Government-minister-marry-lesbian-partner--Harman-blurts-TUC-conference.html\">blurted it out</a> to the TUC and the world from the conference platform. What better civil partnership present for them than the dismissal of Edwards from his job in time for the ceremony.</p>",
+      "inBodyElements": [],
+      "bodyBlocks": [],
+      "closeAllTagsCleaner": {}
+    },
+    "liveBloggingNow": false,
+    "lockedOnOES": false,
+    "overridingOES": false,
+    "edition": 0,
+    "panels": [],
+    "creationAndLastModifiedDetail": {
+      "createdOn": "2015-11-19T14:17:25.978Z",
+      "modifiedOn": "2015-11-19T14:17:25.978Z"
+    },
+    "factboxes": [],
+    "platformPictures": [],
+    "editedSlug": "equality.tradeunions",
+    "publishOnCom": false,
+    "tags": [
+      10528,
+      17019,
+      9184,
+      20040,
+      8798,
+      8791,
+      19796,
+      15555,
+      26903,
+      4
+    ],
+    "editorial": true,
+    "publicationDate": "2008-09-11T00:00:00.000+01:00",
+    "webPublicationDateTime": "2008-09-11T19:35:01.000+01:00",
+    "updateWebPublicationDateTimeOnLaunch": true,
+    "relatedEditorialOff": false,
+    "pages": [
+      {
+        "id": 1083349,
+        "readyToLive": false,
+        "badgesOff": false,
+        "trailText": "<p><strong>David Hencke:</strong> Joel Edwards, whose organisation says homosexuality is morally wrong, is an equality commissioner. He should be fired</p>",
+        "linkText": "David Hencke: Inequality commission ",
+        "isExternalRss": false,
+        "isBlockAds": false,
+        "cmsPath": {
+          "path": "/Guardian/commentisfree/2008/sep/11/equality.tradeunions"
+        },
+        "seciton": 241,
+        "createdBy": "David Shariatmadari",
+        "lastModifiedBy": "Becky Carroll",
+        "createdOn": "2008-09-11T16:37:48.000+01:00",
+        "modifiedOn": "2008-09-11T18:02:05.000+01:00",
+        "lastLiveTime": "2008-09-11T19:35:01.000+01:00",
+        "webPublicationTime": "2008-09-11T19:35:01.000+01:00",
+        "launchableTemplate": {
+          "displayName": "Article",
+          "staticName": "Article",
+          "location": "templates/common/article",
+          "stylesheetName": "article-top",
+          "pageTypes": [
+            "ARTICLE"
+          ],
+          "templateCode": 14,
+          "shownInTemplateDropDown": true,
+          "coreContentAreaName": {
+            "name": "article"
+          },
+          "id": 3
+        }
+      }
+    ],
+    "pluckCommentable": true,
+    "pluckPremoderated": false,
+    "synchronisedWithPluck": true,
+    "externalReferences": [],
+    "expired": false,
+    "automateLinking": false,
+    "sensitive": false,
+    "closingDateForCommenting": "2008-09-14T19:35:01.000+01:00",
+    "blockAds": false,
+    "headline": "Inequality commission",
+    "standfirst": "Joel Edwards, whose organisation says homosexuality is morally wrong, is an equality commissioner. He should be fired",
+    "byline": "David Hencke",
+    "id": 337526188
+  },
+  "live": {
+    "liveBloggingNow": false,
+    "contentBody": {
+      "bodyText": "<p>This week, the TUC took a rare decision to campaign to sack someone.</p><p>The conference, which normally fights to the last man and woman for anybody in a job, took the view that Joel Edwards, commissioner to the Equality and Human Rights Commission, should be <a href=\"http://www.pinknews.co.uk/news/articles/2005-8933.html\">shown the door</a> immediately.</p><p>Edwards is the commissioner, but he is also general director of the <a href=\"http://www.eauk.org/about/whos-who.cfm\">Evangelical Alliance</a> (EA), a fundamentalist Christian group. </p><p>Under his direction, the EA describes gay relationships as sinful and \"a behaviour choice\" and that \"homosexual practice is morally wrong\". His appointment by Ruth Kelly, when she was equalities minister, attracted harsh publicity at the time. But after six months in office, the anger has increased. It boiled over last night at the TUC's lesbian, gay, bisexual and transgender (LGBT) fringe meeting, where a commission official was given the unenviable task of trying to defend Edwards to a polite but hostile audience. He failed.</p><p>I am behind the TUC on this one. What on earth was Trevor Phillips doing, agreeing to allow the government to appoint someone who thinks being gay is some form of undesirable behaviour choice? What will he sanction next? How about appointing a commissioner for race relations from the South African Dutch Reformed Church who might believe that blacks are inferior to whites and can cite the Bible on this?</p><p>The response from the commissioner's office was pathetic. Evidently, Trevor Phillips, its head, is such a frightened rabbit that he daren't say anything to Harriet Harman, the current equalities minister, about it. In a typical buck-passing, bureaucratic moment, press officials passed it to the <a href=\"http://www.equalities.gov.uk/\">Equalities Office</a>, saying they were powerless over the appointment process. What piffle – if they were unhappy, they could do something.</p><p>And the present position is insulting for thousands of gay people – not least among them some of Harriet Harman's gay friends such as Angela Eagle, the Treasury minister and her partner, Maria Exall, chair of the TUC LGBT group and TUC council member. It's bizarre to consider that a man at the head of the commission thinks influential Tory blogger Iain Dale, Conservative frontbencher Alan Duncan and health minister Ben Bradshaw are in sinful relationships which are an unfortunate behaviour choice. No doubt in true Bibical terms, he will treat them as \"lost sheep\" that can be rounded up and repent of their sins.</p><p>Yesterday, Harriet Harman turned the private decision of Maria Exall and Angela Eagle to join a civil partnership into a government announcement when she <a href=\"http://www.mailonsunday.co.uk/news/article-1054339/Government-minister-marry-lesbian-partner--Harman-blurts-TUC-conference.html\">blurted it out</a> to the TUC and the world from the conference platform. What better civil partnership present for them than the dismissal of Edwards from his job in time for the ceremony.</p>",
+      "inBodyElements": [],
+      "bodyBlocks": [],
+      "closeAllTagsCleaner": {}
+    },
+    "lockedOnOES": false,
+    "overridingOES": false,
+    "panels": [],
+    "lastLiveTime": "2008-09-11T19:35:01.000+01:00",
+    "factboxes": [],
+    "platformPictures": [],
+    "tags": [
+      10528,
+      17019,
+      9184,
+      20040,
+      8798,
+      8791,
+      19796,
+      15555,
+      26903,
+      4
+    ],
+    "editorial": true,
+    "publicationDate": "2008-09-11T00:00:00.000+01:00",
+    "webPublicationDateTime": "2008-09-11T19:35:01.000+01:00",
+    "updateWebPublicationDateTimeOnLaunch": true,
+    "relatedEditorialOff": false,
+    "pages": [
+      {
+        "id": 1083349,
+        "readyToLive": false,
+        "badgesOff": false,
+        "trailText": "<p><strong>David Hencke:</strong> Joel Edwards, whose organisation says homosexuality is morally wrong, is an equality commissioner. He should be fired</p>",
+        "linkText": "David Hencke: Inequality commission ",
+        "isExternalRss": false,
+        "isBlockAds": false,
+        "cmsPath": {
+          "path": "/Guardian/commentisfree/2008/sep/11/equality.tradeunions"
+        },
+        "seciton": 241,
+        "createdBy": "David Shariatmadari",
+        "lastModifiedBy": "Becky Carroll",
+        "createdOn": "2008-09-11T16:37:48.000+01:00",
+        "modifiedOn": "2008-09-11T18:02:05.000+01:00",
+        "lastLiveTime": "2008-09-11T19:35:01.000+01:00",
+        "webPublicationTime": "2008-09-11T19:35:01.000+01:00",
+        "launchableTemplate": {
+          "displayName": "Article",
+          "staticName": "Article",
+          "location": "templates/common/article",
+          "stylesheetName": "article-top",
+          "pageTypes": [
+            "ARTICLE"
+          ],
+          "templateCode": 14,
+          "shownInTemplateDropDown": true,
+          "coreContentAreaName": {
+            "name": "article"
+          },
+          "id": 3
+        }
+      }
+    ],
+    "pluckCommentable": true,
+    "pluckPremoderated": false,
+    "synchronisedWithPluck": true,
+    "externalReferences": [],
+    "expired": false,
+    "automateLinking": false,
+    "sensitive": false,
+    "closingDateForCommenting": "2008-09-14T19:35:01.000+01:00",
+    "blockAds": false,
+    "headline": "Inequality commission",
+    "standfirst": "Joel Edwards, whose organisation says homosexuality is morally wrong, is an equality commissioner. He should be fired",
+    "byline": "David Hencke",
+    "productionOffice": "UK",
+    "id": 337526188
+  }
+}

--- a/test/services/migration/r2ToFlexConversion/R2ToFlexArticleConversionSpec.scala
+++ b/test/services/migration/r2ToFlexConversion/R2ToFlexArticleConversionSpec.scala
@@ -106,7 +106,16 @@ class R2ToFlexArticleConversionSpec extends Specification with Mockito {
       subscriptionDatabases must equalTo(Some(true))
       developerCommunity must equalTo(Some(true))
     }
+    "second article" in {
+      val xml = R2ToFlexArticleConversion.parseDraftData(r2Json("/migration/r2article2.json")).xml
+      (xml \ "@enable-comments").text.toString must equalTo("true")
+      (xml \ "@premoderation").text.toString must equalTo("false")
+      (xml \ "@comment-expiry-date").text.toString must equalTo("200809141935")
+      (xml \ "@issue-date").text.toString must equalTo("20080911")
+    }
   }
+
+
 
 
 


### PR DESCRIPTION
ensures that all fields are being sent on article migration