### PR TITLE
article filter article migration by tag ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,6 @@ code: `curl -X POST "http://flexcontentmigrator.code.dev-gutools.co.uk/migrate/a
 
 ####Batch
 
-local: `curl -X POST "http://localhost:9100/migrate/article?batchNumber=${batchNumber}&batchSize=${batchSize}"`
+local: `curl -X POST "http://localhost:9100/migrate/article?batchNumber=${batchNumber}&batchSize=${batchSize}&tagIds=${tagId1,tagId2}"`
 
-code:   `curl -X POST "http://flexcontentmigrator.code.dev-gutools.co.uk/migrate/article?batchNumber=${batchNumber}&batchSize=${batchSize}"`
+code:   `curl -X POST "http://flexcontentmigrator.code.dev-gutools.co.uk/migrate/article?batchNumber=${batchNumber}&batchSize=${batchSize}&tagIds=${tagId1,tagId2}"`

--- a/app/controllers/migration/ArticleMigrationApi.scala
+++ b/app/controllers/migration/ArticleMigrationApi.scala
@@ -37,10 +37,10 @@ class ArticleMigrationApi(migrator : Migrator, reporter : MigrationReport, flex 
     flex.doConnectivityCheck.map(response => Ok(response))
   }}
 
-  def migrateBatch(batchSize : Option[Int], batchNumber : Option[Int] ) = Action.async{ block => {
-    Logger.debug(s"migrateBatch ${batchSize} ${batchNumber}")
+  def migrateBatch(batchSize : Option[Int], batchNumber : Option[Int], tagIds : Option[String] ) = Action.async{ block => {
+    Logger.debug(s"migrateBatch ${batchSize} ${batchNumber} ${tagIds}")
     withMigrationPermission{ () =>
-      migrator.migrateBatchOfContent(batchSize, batchNumber).map(reportMigratedBatch(_))
+      migrator.migrateBatchOfContent(batchSize, batchNumber, tagIds).map(reportMigratedBatch(_))
     }
   }
   }

--- a/app/services/migration/Migrator.scala
+++ b/app/services/migration/Migrator.scala
@@ -22,7 +22,6 @@ protected[migration] trait MigrationBehaviour{
   val pushToFlex : PushToFlex
   val closeContentInSource : MigrateContentInR2
 
-
 }
 
 
@@ -43,10 +42,10 @@ trait Migrator{
     }
   }
 
-  def migrateBatchOfContent(size : Option[Int], batchNumber : Option[Int]) : Future[MigratedBatch] = {
+  def migrateBatchOfContent(size : Option[Int], batchNumber : Option[Int], tagIds : Option[String] = None) : Future[MigratedBatch] = {
     val batchSize = getBatchSize(size)
     val batchOffset = batchNumber.getOrElse(1)
-    migrateBatch(batchSize, batchOffset)
+    migrateBatch(batchSize, batchOffset, tagIds)
   }
 
   def migrateIndividualContent(contentId : Int) : Future[ContentMigrationResult] = {

--- a/app/services/migration/batch/BatchMigrator.scala
+++ b/app/services/migration/batch/BatchMigrator.scala
@@ -206,12 +206,12 @@ protected[batch] class AkkaBatchMigratorOrchestrator(migrationBehaviour : Migrat
   private def startMigration(resultsListener : ActorRef) = {
     //TODO: prevent future start requests coming in!
     Logger.debug(s"startMigration")
-    val videoIds: Future[List[Int]] = migrationBehaviour.contentLoader.getBatchOfContentIds(size, batchNumber)
-    videoIds.onSuccess[Unit]{
+    val contentIds: Future[List[Int]] = migrationBehaviour.contentLoader.getBatchOfContentIds(size, batchNumber, tagIds)
+    contentIds.onSuccess[Unit]{
       case ids : List[Int] => idsInCurrentBatch = ids
     }
-    videoIds.map{_.map{ r2VideoId =>
-      actorR2Loader ! LoadContentR2Msg(batchId, r2VideoId, resultsListener)
+    contentIds.map{_.map{ r2ContentId =>
+      actorR2Loader ! LoadContentR2Msg(batchId, r2ContentId, resultsListener)
     }}
   }
 }

--- a/app/services/migration/r2/R2AritcleMigrationService.scala
+++ b/app/services/migration/r2/R2AritcleMigrationService.scala
@@ -20,10 +20,8 @@ abstract class R2ArticleMigratorService(client : R2IntegrationAPIClient) extends
 
   def loadContentById(id : Integer) = loadContentWithThrottle(id)
 
-  def getBatchOfContentIds(batchSize : Int, batchOffset : Int) =
-    getBatchOfContentIds(batchSize, batchOffset, None)
 
-  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String]) =
+  override def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String]) =
     client.getBatchOfArticleIds(batchSize, batchOffset, tagIds)
 
 

--- a/app/services/migration/r2/R2AritcleMigrationService.scala
+++ b/app/services/migration/r2/R2AritcleMigrationService.scala
@@ -20,18 +20,21 @@ abstract class R2ArticleMigratorService(client : R2IntegrationAPIClient) extends
 
   def loadContentById(id : Integer) = loadContentWithThrottle(id)
 
-
   def getBatchOfContentIds(batchSize : Int, batchOffset : Int) =
-    client.getBatchOfArticleIds(batchSize, batchOffset)
+    getBatchOfContentIds(batchSize, batchOffset, None)
 
-  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1) : Future[MigrationBatch] = {
+  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String]) =
+    client.getBatchOfArticleIds(batchSize, batchOffset, tagIds)
+
+
+  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None) : Future[MigrationBatch] = {
     def mapIdsToArticles(ids: Future[List[Int]]) = {
       def idsToArticles(ids : List[Int]) = ids.map(loadContentWithThrottle(_))
 
       ids.map{idsToArticles(_)}.flatMap(Future.sequence(_))
     }
 
-    val ids = client.getBatchOfArticleIds(batchSize, batchNumber)
+    val ids = client.getBatchOfArticleIds(batchSize, batchNumber, tagIds)
     val audios = mapIdsToArticles(ids)
     audios.map(loadedArticles => {
       Logger.info(s"Loaded the batch of ${batchSize} articles from R2")

--- a/app/services/migration/r2/R2AudioMigrationService.scala
+++ b/app/services/migration/r2/R2AudioMigrationService.scala
@@ -24,12 +24,15 @@ abstract class R2AudioMigratorService(client : R2IntegrationAPIClient) extends R
   def getBatchOfContentIds(batchSize : Int, batchOffset : Int) =
     client.getBatchOfAudioIds(batchSize, batchOffset)
 
-  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1) : Future[MigrationBatch] = {
+
+  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String]) : Future[MigrationBatch] = {
     def mapIdsToAudios(ids: Future[List[Int]]) = {
       def idsToAudios(ids : List[Int]) = ids.map(loadContentWithThrottle(_))
 
       ids.map{idsToAudios(_)}.flatMap(Future.sequence(_))
     }
+
+    if(tagIds.isDefined) throw new UnsupportedOperationException("Tag specific migration not supported for audios")
 
     val ids = client.getBatchOfAudioIds(batchSize, batchNumber)
     val audios = mapIdsToAudios(ids)

--- a/app/services/migration/r2/R2CartoonMigrationService.scala
+++ b/app/services/migration/r2/R2CartoonMigrationService.scala
@@ -24,12 +24,13 @@ abstract class R2CartoonMigratorService(client : R2IntegrationAPIClient) extends
   def getBatchOfContentIds(batchSize : Int, batchOffset : Int) =
     client.getBatchOfCartoonIds(batchSize, batchOffset)
 
-  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1) : Future[MigrationBatch] = {
+  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None) : Future[MigrationBatch] = {
     def mapIdsToCartoons(ids: Future[List[Int]]) = {
       def idsToCartoons(ids : List[Int]) = ids.map(loadContentWithThrottle(_))
 
       ids.map{idsToCartoons(_)}.flatMap(Future.sequence(_))
     }
+    if(tagIds.isDefined) throw new UnsupportedOperationException("Tag specific migration not supported for cartoons")
 
     val ids = client.getBatchOfCartoonIds(batchSize, batchNumber)
     val cartoons = mapIdsToCartoons(ids)

--- a/app/services/migration/r2/R2CartoonMigrationService.scala
+++ b/app/services/migration/r2/R2CartoonMigrationService.scala
@@ -21,8 +21,8 @@ abstract class R2CartoonMigratorService(client : R2IntegrationAPIClient) extends
   def loadContentById(id : Integer) = loadContentWithThrottle(id)
 
 
-  def getBatchOfContentIds(batchSize : Int, batchOffset : Int) =
-    client.getBatchOfCartoonIds(batchSize, batchOffset)
+  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String] = None) =
+    client.getBatchOfCartoonIds(batchSize, batchOffset, tagIds)
 
   def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None) : Future[MigrationBatch] = {
     def mapIdsToCartoons(ids: Future[List[Int]]) = {
@@ -30,9 +30,8 @@ abstract class R2CartoonMigratorService(client : R2IntegrationAPIClient) extends
 
       ids.map{idsToCartoons(_)}.flatMap(Future.sequence(_))
     }
-    if(tagIds.isDefined) throw new UnsupportedOperationException("Tag specific migration not supported for cartoons")
 
-    val ids = client.getBatchOfCartoonIds(batchSize, batchNumber)
+    val ids = client.getBatchOfCartoonIds(batchSize, batchNumber, tagIds)
     val cartoons = mapIdsToCartoons(ids)
     cartoons.map(loadedCartoons => {
       Logger.info(s"Loaded the batch of ${batchSize} cartoons from R2")

--- a/app/services/migration/r2/R2GalleryMigrationService.scala
+++ b/app/services/migration/r2/R2GalleryMigrationService.scala
@@ -24,12 +24,14 @@ abstract class R2GalleryMigratorService(client : R2IntegrationAPIClient) extends
   def getBatchOfContentIds(batchSize : Int, batchOffset : Int) =
     client.getBatchOfGalleryIds(batchSize, batchOffset)
 
-  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1) : Future[MigrationBatch] = {
+  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None) : Future[MigrationBatch] = {
     def mapIdsToGalleries(ids: Future[List[Int]]) = {
       def idsToGalleries(ids : List[Int]) = ids.map(loadContentWithThrottle(_))
 
       ids.map{idsToGalleries(_)}.flatMap(Future.sequence(_))
     }
+
+    if(tagIds.isDefined) throw new UnsupportedOperationException("Tag specific migration not supported for galleries")
 
     val ids = client.getBatchOfGalleryIds(batchSize, batchNumber)
     val galleries = mapIdsToGalleries(ids)

--- a/app/services/migration/r2/R2GalleryMigrationService.scala
+++ b/app/services/migration/r2/R2GalleryMigrationService.scala
@@ -21,8 +21,8 @@ abstract class R2GalleryMigratorService(client : R2IntegrationAPIClient) extends
   def loadContentById(id : Integer) = loadContentWithThrottle(id)
 
 
-  def getBatchOfContentIds(batchSize : Int, batchOffset : Int) =
-    client.getBatchOfGalleryIds(batchSize, batchOffset)
+  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String] = None) =
+    client.getBatchOfGalleryIds(batchSize, batchOffset, tagIds)
 
   def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None) : Future[MigrationBatch] = {
     def mapIdsToGalleries(ids: Future[List[Int]]) = {
@@ -31,9 +31,7 @@ abstract class R2GalleryMigratorService(client : R2IntegrationAPIClient) extends
       ids.map{idsToGalleries(_)}.flatMap(Future.sequence(_))
     }
 
-    if(tagIds.isDefined) throw new UnsupportedOperationException("Tag specific migration not supported for galleries")
-
-    val ids = client.getBatchOfGalleryIds(batchSize, batchNumber)
+    val ids = client.getBatchOfGalleryIds(batchSize, batchNumber, tagIds)
     val galleries = mapIdsToGalleries(ids)
     galleries.map(loadedGalleries => {
       Logger.info(s"Loaded the batch of ${batchSize} galleries from R2")

--- a/app/services/migration/r2/R2IntegrationAPIClient.scala
+++ b/app/services/migration/r2/R2IntegrationAPIClient.scala
@@ -143,25 +143,29 @@ protected[migration] class R2IntegrationAPIClient {
   
 
 
-  protected[migration] def getBatchOfGalleryIds(batchSize : Int, batchNumber : Int) : Future[List[Int]] = {
+  protected[migration] def getBatchOfGalleryIds(batchSize : Int, batchNumber : Int, tagIds : Option[String]=None) : Future[List[Int]] = {
+    if(tagIds.isDefined) throw new UnsupportedOperationException("Specific tagId migration not supported for galleries")
     WS.url(requestGalleriesToMigrate(batchSize, batchNumber)).get().map{response =>
       (response.json \ "elementsOnCurrentPage").as[List[Int]]
     }
   }
 
-  protected[migration] def getBatchOfCartoonIds(batchSize : Int, batchNumber : Int) : Future[List[Int]] = {
+  protected[migration] def getBatchOfCartoonIds(batchSize : Int, batchNumber : Int, tagIds : Option[String]=None) : Future[List[Int]] = {
+    if(tagIds.isDefined) throw new UnsupportedOperationException("Specific tagId migration not supported for cartoons")
     WS.url(requestCartoonsToMigrate(batchSize, batchNumber)).get().map{response =>
       (response.json \ "elementsOnCurrentPage").as[List[Int]]
     }
   }
 
-  protected[migration] def getBatchOfQuizIds(batchSize : Int, batchNumber : Int) : Future[List[Int]] = {
+  protected[migration] def getBatchOfQuizIds(batchSize : Int, batchNumber : Int, tagIds : Option[String]=None) : Future[List[Int]] = {
+    if(tagIds.isDefined) throw new UnsupportedOperationException("Specific tagId migration not supported for quizzes")
     WS.url(requestQuizzesToMigrate(batchSize, batchNumber)).get().map{response =>
       (response.json \ "elementsOnCurrentPage").as[List[Int]]
     }
   }
 
-  protected[migration] def getBatchOfAudioIds(batchSize : Int, batchNumber : Int) : Future[List[Int]] = {
+  protected[migration] def getBatchOfAudioIds(batchSize : Int, batchNumber : Int, tagIds : Option[String]=None) : Future[List[Int]] = {
+    if(tagIds.isDefined) throw new UnsupportedOperationException("Specific tagId migration not supported for audios")
     WS.url(requestAudiosToMigrate(batchSize, batchNumber)).get().map{response =>
       (response.json \ "elementsOnCurrentPage").as[List[Int]]
     }
@@ -259,9 +263,8 @@ trait R2MigrationService{
 
   def loadContentById(id : Integer) : Future[SourceContent]
 
-  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None) : Future[MigrationBatch]
-
-  def getBatchOfContentIds(batchSize : Int, batchOffset : Int) : Future[List[Int]]
+  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String]) : Future[MigrationBatch]
+  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String]) : Future[List[Int]]
 
   def migrateContentInR2(contentId : Int, composerId : String) : Future[(Boolean, String)]
 

--- a/app/services/migration/r2/R2QuizMigrationService.scala
+++ b/app/services/migration/r2/R2QuizMigrationService.scala
@@ -24,12 +24,13 @@ abstract class R2QuizMigratorService(client : R2IntegrationAPIClient) extends R2
   def getBatchOfContentIds(batchSize : Int, batchOffset : Int) =
     client.getBatchOfQuizIds(batchSize, batchOffset)
 
-  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1) : Future[MigrationBatch] = {
+  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None) : Future[MigrationBatch] = {
     def mapIdsToQuizzes(ids: Future[List[Int]]) = {
       def idsToQuizzes(ids : List[Int]) = ids.map(loadContentWithThrottle(_))
 
       ids.map{idsToQuizzes(_)}.flatMap(Future.sequence(_))
     }
+    if(tagIds.isDefined) throw new UnsupportedOperationException("Tag specific migration not supported for quizzes")
 
     val ids = client.getBatchOfGalleryIds(batchSize, batchNumber)
     val quizzes = mapIdsToQuizzes(ids)

--- a/app/services/migration/r2/R2QuizMigrationService.scala
+++ b/app/services/migration/r2/R2QuizMigrationService.scala
@@ -24,15 +24,19 @@ abstract class R2QuizMigratorService(client : R2IntegrationAPIClient) extends R2
   def getBatchOfContentIds(batchSize : Int, batchOffset : Int) =
     client.getBatchOfQuizIds(batchSize, batchOffset)
 
+  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String] = None) ={
+    getBatchOfContentIds(batchSize, batchOffset, tagIds)
+  }
+
+
   def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None) : Future[MigrationBatch] = {
     def mapIdsToQuizzes(ids: Future[List[Int]]) = {
       def idsToQuizzes(ids : List[Int]) = ids.map(loadContentWithThrottle(_))
 
       ids.map{idsToQuizzes(_)}.flatMap(Future.sequence(_))
     }
-    if(tagIds.isDefined) throw new UnsupportedOperationException("Tag specific migration not supported for quizzes")
 
-    val ids = client.getBatchOfGalleryIds(batchSize, batchNumber)
+    val ids = client.getBatchOfGalleryIds(batchSize, batchNumber, tagIds)
     val quizzes = mapIdsToQuizzes(ids)
     quizzes.map(loadedQuizzes => {
       Logger.info(s"Loaded the batch of ${batchSize} quizzes from R2")

--- a/app/services/migration/r2/R2QuizMigrationService.scala
+++ b/app/services/migration/r2/R2QuizMigrationService.scala
@@ -20,14 +20,9 @@ abstract class R2QuizMigratorService(client : R2IntegrationAPIClient) extends R2
 
   def loadContentById(id : Integer) = loadContentWithThrottle(id)
 
-
-  def getBatchOfContentIds(batchSize : Int, batchOffset : Int) =
-    client.getBatchOfQuizIds(batchSize, batchOffset)
-
   def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String] = None) ={
-    getBatchOfContentIds(batchSize, batchOffset, tagIds)
+    client.getBatchOfQuizIds(batchSize, batchOffset, tagIds)
   }
-
 
   def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None) : Future[MigrationBatch] = {
     def mapIdsToQuizzes(ids: Future[List[Int]]) = {

--- a/conf/routes
+++ b/conf/routes
@@ -24,7 +24,7 @@ POST        /migrate/audio/:audio_id         controllers.migration.AudioMigratio
 
 GET         /article                         controllers.migration.ArticleMigrationApi.articlePage
 GET         /check/article                   controllers.migration.ArticleMigrationApi.checkFlexConnection
-POST        /migrate/article                 controllers.migration.ArticleMigrationApi.migrateBatch(batchSize: Option[Int] ?=None, batchNumber : Option[Int] ?=None)
+POST        /migrate/article                 controllers.migration.ArticleMigrationApi.migrateBatch(batchSize: Option[Int] ?=None, batchNumber : Option[Int] ?=None, tagIds : Option[String] ?=None)
 POST        /migrate/article/:article_id     controllers.migration.ArticleMigrationApi.migrateArticle(article_id : Int)
 POST        /migrate/article/json/:article_id     controllers.migration.ArticleMigrationApi.migrateArticleJson(article_id : Int)
 

--- a/start-flex-content-migrator.sh
+++ b/start-flex-content-migrator.sh
@@ -1,2 +1,2 @@
 echo "Starts local Flex Content Migrator using SBT for testing"
-sbt "run -Dconfig.resource=application.local.conf 9100"
+./sbt "run -Dconfig.resource=application.local.conf 9100"

--- a/test/services/migration/GalleryMigratorSpec.scala
+++ b/test/services/migration/GalleryMigratorSpec.scala
@@ -44,7 +44,7 @@ class GalleryMigratorSpec extends Specification with Mockito {
   private def migrator : Migrator = {
     val r2GalleryMigrator = mock[R2GalleryMigratorService]
     r2GalleryMigrator.loadContentById(any[Int]) returns Future{galleries.head}
-    r2GalleryMigrator.getBatchOfContentIds(any[Int], any[Int]) returns Future{(1 to NumberOfGalleries).toList}
+    r2GalleryMigrator.getBatchOfContentIds(any[Int], any[Int], any[Option[String]]) returns Future{(1 to NumberOfGalleries).toList}
     r2GalleryMigrator.migrateContentInR2(any[Int], any[String]) returns Future{(true, "gallery migrated in r2")}
 
     val flexGalleryMigrationService = mock[FlexContentMigrationService]

--- a/test/services/migration/batch/BatchMigratorSpec.scala
+++ b/test/services/migration/batch/BatchMigratorSpec.scala
@@ -23,7 +23,7 @@ class BatchMigratorSpec extends Specification with Mockito {
       val themock = mock[R2GalleryMigratorService]
       themock.getBatchOfContentIds(batchSize, batchOffset) returns Future{(1 to batchSize).toList}
       themock.loadContentById(any[Int]) returns Future{srcVideo}
-      themock.loadBatchOfContent(any[Int], any[Int]) returns Future{ MigrationBatch({for(i <- 1 to batchSize) yield srcVideo}.toList)}
+      themock.loadBatchOfContent(any[Int], any[Int], any[Option[String]]) returns Future{ MigrationBatch({for(i <- 1 to batchSize) yield srcVideo}.toList)}
       themock
     }
 
@@ -79,7 +79,7 @@ class BatchMigratorSpec extends Specification with Mockito {
         if(count%2==0) throw new RuntimeException("Something went BANG!")
         Future{srcVideo}
       }
-      themock.loadBatchOfContent(any[Int], any[Int]) returns Future{ MigrationBatch({for(i <- 1 to batchSize) yield srcVideo}.toList)}
+      themock.loadBatchOfContent(any[Int], any[Int], any[Option[String]]) returns Future{ MigrationBatch({for(i <- 1 to batchSize) yield srcVideo}.toList)}
       themock
     }
 

--- a/test/services/migration/batch/BatchMigratorSpec.scala
+++ b/test/services/migration/batch/BatchMigratorSpec.scala
@@ -3,6 +3,7 @@ package services.migration.batch
 import java.util.concurrent.atomic.AtomicInteger
 import model._
 import org.specs2.mock.Mockito
+import org.mockito.Matchers.{eq => eqTo, _}
 import org.specs2.mutable.Specification
 import play.api.test.Helpers
 import services.migration._
@@ -21,7 +22,7 @@ class BatchMigratorSpec extends Specification with Mockito {
 
     def mockR2VideoMigrator(batchSize: Int, batchOffset : Int) : R2GalleryMigratorService = {
       val themock = mock[R2GalleryMigratorService]
-      themock.getBatchOfContentIds(batchSize, batchOffset) returns Future{(1 to batchSize).toList}
+      themock.getBatchOfContentIds(eqTo(batchSize), eqTo(batchOffset), any[Option[String]]) returns Future{(1 to batchSize).toList}
       themock.loadContentById(any[Int]) returns Future{srcVideo}
       themock.loadBatchOfContent(any[Int], any[Int], any[Option[String]]) returns Future{ MigrationBatch({for(i <- 1 to batchSize) yield srcVideo}.toList)}
       themock
@@ -73,7 +74,7 @@ class BatchMigratorSpec extends Specification with Mockito {
 
     override def mockR2VideoMigrator(batchSize: Int, batchOffset : Int) : R2GalleryMigratorService = {
       val themock = mock[R2GalleryMigratorService]
-      themock.getBatchOfContentIds(batchSize, batchOffset) returns Future{(1 to batchSize).toList}
+      themock.getBatchOfContentIds(eqTo(batchSize), eqTo(batchOffset), any[Option[String]]) returns Future{(1 to batchSize).toList}
       themock.loadContentById(any[Int]) answers { m =>
         val count = counterR2.incrementAndGet()
         if(count%2==0) throw new RuntimeException("Something went BANG!")
@@ -101,7 +102,7 @@ class BatchMigratorSpec extends Specification with Mockito {
 
     override def mockR2VideoMigrator(batchSize: Int, batchOffset : Int) : R2GalleryMigratorService = {
       val themock = mock[R2GalleryMigratorService]
-      themock.getBatchOfContentIds(batchSize, batchOffset) returns Future{(1 to batchSize).toList}
+      themock.getBatchOfContentIds(batchSize, batchOffset, any[Option[String]]) returns Future{(1 to batchSize).toList}
       themock.loadContentById(any[Int]) answers { m =>
         r2ThrottlerFt[SourceContent]{
           Future{srcVideo}
@@ -129,7 +130,7 @@ class BatchMigratorSpec extends Specification with Mockito {
 
     override def mockR2VideoMigrator(batchSize: Int, batchOffset : Int) : R2GalleryMigratorService = {
       val themock = mock[R2GalleryMigratorService]
-      themock.getBatchOfContentIds(batchSize, batchOffset) returns Future{(1 to batchSize).toList}
+      themock.getBatchOfContentIds(batchSize, batchOffset, any[Option[String]]) returns Future{(1 to batchSize).toList}
       themock.loadContentById(any[Int]) answers { m =>
         Thread.sleep(SleepForAges)
         Future{srcVideo}


### PR DESCRIPTION
Flows tag Ids through to R2 when loading articles so that we can migrate content on specific tags
