### PR TITLE
Monitors: change the queue size

### DIFF
--- a/app/services/aws/monitors.scala
+++ b/app/services/aws/monitors.scala
@@ -70,7 +70,7 @@ class SqsQueueMonitor(  sqsEndpoint : String,
                         awsAccessKey : String,
                         awsSecretKey : String) extends MigrationDependencyMonitor {
 
-  val MaxDepth = 200
+  val MaxDepth = 1500
   val HangBackTime = 10000;
 
   private lazy val sqsClient = {


### PR DESCRIPTION
The current queue depth is too conservative based on what R2 seems able to consume