### PR TITLE
restartable straight sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ prod:   `curl -X POST "http://flexcontentmigrator.gutools.co.uk/migrate/article?
 
 ####Multi Batch
 
-There are two scripts that will both run a set number of batches (a multi batch) on your machine.
+There are three scripts that will both run a set number of batches (a multi batch) on your machine.
 
-`runMigrationScriptPROD_randomise.sh`     : runs a set number of batches in a random sequence
-`runMigrationScriptPROD.sh`               : runs a set number of batches in straight sequence
+`runMigrationScriptPROD_randomise.sh`           : runs a set number of batches in a random sequence to avoid retry error cases. 
+`runMigrationScriptPROD_restartableSequence.sh` : runs a set number of batches in straight sequence. Avoids getting stuck on errors by not retrying the same content twice. It can pick up near where it left of or it can start again from the beginging
+`runMigrationScriptPROD.sh`                     : deprecated, replaced by runMigrationScriptPROD_restartableSequence.sh as it can retry failed content indefinately and get stuck
 
-The random sequence is useful if there is some content that will not migrate - it avoids repeatedly re-trying the same content
-Both of these script files log their output to a directory ./migrationOutput
+These script files log their output to a directory ~./migrationOutput
 
 
 ### To Resync R2 

--- a/app/controllers/migration/ArticleMigrationApi.scala
+++ b/app/controllers/migration/ArticleMigrationApi.scala
@@ -8,8 +8,7 @@ import play.api.Logger
 import play.api.mvc.{Action, Result, Controller}
 import services.aws.Monitors._
 import services.{FlexArticleMigrationServiceImpl, FlexContentMigrationService}
-import services.migration.{ArticleMigrator, Migrator}
-import play.api.mvc._
+import services.migration.{MigrationBatchParams, ArticleMigrator, Migrator}
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 
@@ -45,7 +44,7 @@ class ArticleMigrationApi(migrator : Migrator, reporter : MigrationReport, flex 
       try{
         doNotOverloadSubsystems[Future[Result]]{ () =>
 
-          migrator.migrateBatchOfContent(batchSize, batchNumber, tagIds, withIdsHigherThan).map(reportMigratedBatch(_))
+          migrator.migrateBatchOfContent(MigrationBatchParams(batchSize, batchNumber, tagIds, withIdsHigherThan)).map(reportMigratedBatch(_))
 
         }
       }

--- a/app/controllers/migration/ArticleMigrationApi.scala
+++ b/app/controllers/migration/ArticleMigrationApi.scala
@@ -45,7 +45,7 @@ class ArticleMigrationApi(migrator : Migrator, reporter : MigrationReport, flex 
       try{
         doNotOverloadSubsystems[Future[Result]]{ () =>
 
-          migrator.migrateBatchOfContent(batchSize, batchNumber, tagIds).map(reportMigratedBatch(_))
+          migrator.migrateBatchOfContent(batchSize, batchNumber, tagIds, withIdsHigherThan).map(reportMigratedBatch(_))
 
         }
       }
@@ -174,7 +174,7 @@ object ArticleMigrationTextReport extends MigrationReport{
     def batchFailureReport =
       s"Details:\n${reportSuccesses(batch.migrated)}\n\n${batch.failed.map(reportFailure(_) + "\n\n").mkString("\n")}"
     def highestIdAttempted =
-      (batch.migrated.map(_.id) :: batch.failed.map(_.id) :: Nil).max
+      (batch.migrated.map(_.id) ++ batch.failed.map(_.id)).max
 
     s"""
        |Batch Success Articles = ${batch.migrated.size}, Failed Articles = ${batch.failed.size}\n

--- a/app/controllers/migration/ArticleMigrationApi.scala
+++ b/app/controllers/migration/ArticleMigrationApi.scala
@@ -38,8 +38,8 @@ class ArticleMigrationApi(migrator : Migrator, reporter : MigrationReport, flex 
     flex.doConnectivityCheck.map(response => Ok(response))
   }}
 
-  def migrateBatch(batchSize : Option[Int], batchNumber : Option[Int], tagIds : Option[String] ) = Action.async{ block => {
-    Logger.debug(s"migrateBatch ${batchSize} ${batchNumber} ${tagIds}")
+  def migrateBatch(batchSize : Option[Int], batchNumber : Option[Int], tagIds : Option[String], withIdsHigherThan : Option[Int] ) = Action.async{ block => {
+    Logger.debug(s"migrateBatch ${batchSize} ${batchNumber} ${tagIds} ${withIdsHigherThan}")
 
     withMigrationPermission{ () =>
       try{
@@ -173,7 +173,13 @@ object ArticleMigrationTextReport extends MigrationReport{
   override def reportMigratedBatch(batch : MigratedBatch) = {
     def batchFailureReport =
       s"Details:\n${reportSuccesses(batch.migrated)}\n\n${batch.failed.map(reportFailure(_) + "\n\n").mkString("\n")}"
-    
-    s"Batch Success Articles = ${batch.migrated.size}, Failed Articles = ${batch.failed.size} \n${batchFailureReport}"
+    def highestIdAttempted =
+      (batch.migrated.map(_.id) :: batch.failed.map(_.id) :: Nil).max
+
+    s"""
+       |Batch Success Articles = ${batch.migrated.size}, Failed Articles = ${batch.failed.size}\n
+       |Highest Attempted Id: ${highestIdAttempted}\n
+       |${batchFailureReport}
+     """.stripMargin
   }
 }

--- a/app/controllers/migration/AudioMigrationApi.scala
+++ b/app/controllers/migration/AudioMigrationApi.scala
@@ -4,7 +4,7 @@ import model._
 import play.api.Logger
 import play.api.mvc.{Action, Result, Controller}
 import services.{FlexAudioMigrationServiceImpl, FlexContentMigrationService}
-import services.migration.{AudioMigrator, Migrator}
+import services.migration.{MigrationBatchParams, AudioMigrator, Migrator}
 
 import scala.concurrent.Future
 
@@ -34,7 +34,7 @@ class AudioMigrationApi(migrator : Migrator, reporter : MigrationReport, flex : 
   def migrateBatch(batchSize : Option[Int], batchNumber : Option[Int] ) = Action.async{ block => {
     Logger.debug(s"migrateBatch ${batchSize} ${batchNumber}")
     withMigrationPermission{ () =>
-      migrator.migrateBatchOfContent(batchSize, batchNumber).map(reportMigratedBatch(_))
+      migrator.migrateBatchOfContent(MigrationBatchParams(batchSize, batchNumber)).map(reportMigratedBatch(_))
     }
   }
   }

--- a/app/controllers/migration/CartoonMigrationApi.scala
+++ b/app/controllers/migration/CartoonMigrationApi.scala
@@ -4,7 +4,7 @@ import model._
 import play.api.Logger
 import play.api.mvc.{Action, Result, Controller}
 import services.{FlexCartoonMigrationServiceImpl, FlexContentMigrationService}
-import services.migration.{CartoonMigrator, Migrator}
+import services.migration.{MigrationBatchParams, CartoonMigrator, Migrator}
 
 import scala.concurrent.Future
 
@@ -34,7 +34,7 @@ class CartoonMigrationApi(migrator : Migrator, reporter : MigrationReport, flex 
   def migrateBatch(batchSize : Option[Int], batchNumber : Option[Int] ) = Action.async{ block => {
     Logger.debug(s"migrateBatch ${batchSize} ${batchNumber}")
     withMigrationPermission{ () =>
-      migrator.migrateBatchOfContent(batchSize, batchNumber).map(reportMigratedBatch(_))
+      migrator.migrateBatchOfContent(MigrationBatchParams(batchSize, batchNumber)).map(reportMigratedBatch(_))
     }
   }
   }

--- a/app/controllers/migration/GalleryMigrationApi.scala
+++ b/app/controllers/migration/GalleryMigrationApi.scala
@@ -4,7 +4,7 @@ import model._
 import play.api.Logger
 import play.api.mvc.{Action, Result, Controller}
 import services.{FlexGalleryMigrationServiceImpl, FlexContentMigrationService}
-import services.migration.{GalleryMigrator, Migrator}
+import services.migration.{MigrationBatchParams, GalleryMigrator, Migrator}
 
 import scala.concurrent.Future
 
@@ -34,7 +34,7 @@ class GalleryMigrationApi(migrator : Migrator, reporter : MigrationReport, flex 
   def migrateBatch(batchSize : Option[Int], batchNumber : Option[Int] ) = Action.async{ block => {
     Logger.debug(s"migrateBatch ${batchSize} ${batchNumber}")
     withMigrationPermission{ () =>
-      migrator.migrateBatchOfContent(batchSize, batchNumber).map(reportMigratedBatch(_))
+      migrator.migrateBatchOfContent(MigrationBatchParams(batchSize, batchNumber)).map(reportMigratedBatch(_))
     }
   }
   }

--- a/app/controllers/migration/QuizMigrationApi.scala
+++ b/app/controllers/migration/QuizMigrationApi.scala
@@ -4,7 +4,7 @@ import model._
 import play.api.Logger
 import play.api.mvc.{Action, Result, Controller}
 import services.{FlexQuizMigrationServiceImpl, FlexContentMigrationService}
-import services.migration.{QuizMigrator, Migrator}
+import services.migration.{MigrationBatchParams, QuizMigrator, Migrator}
 
 import scala.concurrent.Future
 
@@ -34,7 +34,7 @@ class QuizMigrationApi(migrator : Migrator, reporter : MigrationReport, flex : F
   def migrateBatch(batchSize : Option[Int], batchNumber : Option[Int] ) = Action.async{ block => {
     Logger.debug(s"migrateBatch ${batchSize} ${batchNumber}")
     withMigrationPermission{ () =>
-      migrator.migrateBatchOfContent(batchSize, batchNumber).map(reportMigratedBatch(_))
+      migrator.migrateBatchOfContent(MigrationBatchParams(batchSize, batchNumber)).map(reportMigratedBatch(_))
     }
   }
   }

--- a/app/services/migration/MigrationBatchParams.scala
+++ b/app/services/migration/MigrationBatchParams.scala
@@ -1,0 +1,33 @@
+package services.migration
+
+import play.Logger
+
+
+case class MigrationBatchParams private(batchSize : Int, batchNumber : Int, tagIds : Option[String], withIdsHigherThan : Option[Int])
+
+object MigrationBatchParams{
+  import Migrator._
+
+  private def batchSizeOrDefault(batchSize : Option[Int]) : Int = {
+    val size = batchSize.getOrElse(DefaultMigrationBatchSize)
+    if(size<=MaxMigrationBatchSize) size
+    else{
+      Logger.warn(s"Cannot migrate a batch bigger than ${MaxMigrationBatchSize}, migrating ${MaxMigrationBatchSize} only")
+      MaxMigrationBatchSize
+    }
+  }
+
+  private def batchNumberOrDefault(batchNumber : Option[Int]) : Int = {
+    batchNumber.getOrElse(1) match {
+      case x if(x<0) => 1
+      case y : Int => y
+    }
+  }
+
+  def apply(batchSize : Option[Int], batchNumber : Option[Int], tagIds : Option[String] = None, withIdsHigherThan : Option[Int] = None) = {
+    new MigrationBatchParams(batchSizeOrDefault(batchSize), batchNumberOrDefault(batchNumber), tagIds, withIdsHigherThan)
+  }
+}
+
+
+

--- a/app/services/migration/Migrator.scala
+++ b/app/services/migration/Migrator.scala
@@ -42,10 +42,10 @@ trait Migrator{
     }
   }
 
-  def migrateBatchOfContent(size : Option[Int], batchNumber : Option[Int], tagIds : Option[String] = None) : Future[MigratedBatch] = {
+  def migrateBatchOfContent(size : Option[Int], batchNumber : Option[Int], tagIds : Option[String] = None, withIdsHigherThan : Option[Int] = None) : Future[MigratedBatch] = {
     val batchSize = getBatchSize(size)
     val batchOffset = batchNumber.getOrElse(1)
-    migrateBatch(batchSize, batchOffset, tagIds)
+    migrateBatch(batchSize, batchOffset, tagIds, withIdsHigherThan)
   }
 
   def migrateIndividualContent(contentId : Int) : Future[ContentMigrationResult] = {

--- a/app/services/migration/Migrator.scala
+++ b/app/services/migration/Migrator.scala
@@ -2,7 +2,6 @@ package services.migration
 
 
 import model._
-import org.apache.commons.lang3.exception.ExceptionUtils
 import play.Logger
 import services.migration.batch.AkkaBatchMigrator
 import services.migration.r2.R2MigrationService
@@ -29,24 +28,11 @@ trait Migrator{
   protected val migrationBehaviour : MigrationBehaviour
   protected val migrateBatch = AkkaBatchMigrator.migrateBatch(migrationBehaviour) _
 
-
-  import Migrator._
   import play.api.libs.concurrent.Execution.Implicits._
 
-  private def getBatchSize(size : Option[Int]): Int = {
-    val batchSize = size.getOrElse(DefaultMigrationBatchSize)
-    if(batchSize<=MaxMigrationBatchSize) batchSize
-    else{
-      Logger.warn(s"Cannot migrate a batch bigger than ${MaxMigrationBatchSize}, migrating ${MaxMigrationBatchSize} only")
-      MaxMigrationBatchSize
-    }
-  }
 
-  def migrateBatchOfContent(size : Option[Int], batchNumber : Option[Int], tagIds : Option[String] = None, withIdsHigherThan : Option[Int] = None) : Future[MigratedBatch] = {
-    val batchSize = getBatchSize(size)
-    val batchOffset = batchNumber.getOrElse(1)
-    migrateBatch(batchSize, batchOffset, tagIds, withIdsHigherThan)
-  }
+  def migrateBatchOfContent(params : MigrationBatchParams) : Future[MigratedBatch] = migrateBatch(params)
+
 
   def migrateIndividualContent(contentId : Int) : Future[ContentMigrationResult] = {
     val loaded = migrationBehaviour.contentLoader.loadContentById(contentId)

--- a/app/services/migration/batch/BatchMigrator.scala
+++ b/app/services/migration/batch/BatchMigrator.scala
@@ -17,26 +17,26 @@ import scala.concurrent.duration._
 
 protected[migration] trait BatchMigrator{
   def migrateBatch(migrationBehaviour : MigrationBehaviour)
-                  (size: Int, batchNumber : Int, tagIds : Option[String] = None ): Future[MigratedBatch]
+                  (size: Int, batchNumber : Int, tagIds : Option[String] = None, withIdsHigherThan : Option[Int] ): Future[MigratedBatch]
 
 }
 
 protected[migration] object SimpleBatchMigrator extends BatchMigrator{
   override def migrateBatch(migrationBehaviour : MigrationBehaviour)
-                           (size: Int, batchNumber: Int, tagIds : Option[String] = None): Future[MigratedBatch] = {
+                           (size: Int, batchNumber: Int, tagIds : Option[String] = None, withIdsHigherThan : Option[Int] = None): Future[MigratedBatch] = {
     import play.api.libs.concurrent.Execution.Implicits._
 
-    def pushVideosInFlex(batch : MigrationBatch) : Future[Seq[ContentInFlex]]= {
+    def pushContentInFlex(batch : MigrationBatch) : Future[Seq[ContentInFlex]]= {
       Future.sequence(batch.sourceContent.map(migrationBehaviour.contentTransform(_)).map(migrationBehaviour.pushToFlex(_)))
     }
 
-    def migrateVideosInR2(videosInFlex : Seq[ContentInFlex] ) =
-      Future.sequence(videosInFlex.map(video => migrationBehaviour.closeContentInSource(video)))
+    def migrateContentsInR2(contentInFlex : Seq[ContentInFlex] ) =
+      Future.sequence(contentInFlex.map(video => migrationBehaviour.closeContentInSource(video)))
 
 
-    val sourceVideos = migrationBehaviour.contentLoader.loadBatchOfContent(size, batchNumber, tagIds)
-    val videosInFlex = sourceVideos.flatMap(pushVideosInFlex(_))
-    val videosInR2 = videosInFlex.flatMap(vids => migrateVideosInR2(vids))
+    val sourceContent = migrationBehaviour.contentLoader.loadBatchOfContent(size, batchNumber, tagIds, withIdsHigherThan)
+    val videosInFlex = sourceContent.flatMap(pushContentInFlex(_))
+    val videosInR2 = videosInFlex.flatMap(migrateContentsInR2(_))
     videosInR2.map{ results => {
         val resultsSplit = MigrateContentInR2.splitResults(results)
         MigratedBatch(resultsSplit._1, resultsSplit._2)
@@ -51,7 +51,7 @@ protected[migration] object AkkaBatchMigrator extends BatchMigrator{
 
 
   def migrateBatch(migrationBehaviour : MigrationBehaviour)
-                   (size : Int, batchNumber : Int, tagIds : Option[String] ): Future[MigratedBatch] = {
+                   (size : Int, batchNumber : Int, tagIds : Option[String] = None, withIdsHigherThan : Option[Int] = None ): Future[MigratedBatch] = {
     import AkkaBatchMigratorMessages._
     import akka.pattern.ask
     import scala.language.postfixOps
@@ -59,7 +59,7 @@ protected[migration] object AkkaBatchMigrator extends BatchMigrator{
     def batchMigrationOrchestrator(id: String, system : ActorSystem) = {
       system.actorOf( Props(classOf[AkkaBatchMigratorOrchestrator],
                             migrationBehaviour,
-                            id, size, batchNumber, tagIds))
+                            id, size, batchNumber, tagIds, withIdsHigherThan))
     }
 
     withActorSystem{ (id : String , system : ActorSystem) => {
@@ -76,7 +76,6 @@ protected[migration] object AkkaBatchMigrator extends BatchMigrator{
 
   }
 
-
   private def withActorSystem(fn : (String, ActorSystem) => Future[MigratedBatch]) : Future[MigratedBatch] = {
     import scala.concurrent.ExecutionContext.Implicits.global
     val id = migrationBatchId
@@ -88,7 +87,6 @@ protected[migration] object AkkaBatchMigrator extends BatchMigrator{
     })
     future
   }
-
 
 
   private def actorSystem(id : String) = {
@@ -116,7 +114,7 @@ protected[batch] object AkkaBatchMigratorMessages{
     def isSuccess : Boolean
     def listener : ActorRef
   }
-  case class MigratedVideoResultMsg(batchId : String, video : MigratedContent, listener : ActorRef) extends MigrationResult(video.id){
+  case class MigratedContentResultMsg(batchId : String, content : MigratedContent, listener : ActorRef) extends MigrationResult(content.id){
     def isSuccess = true
   }
   case class MigrationErrorResultMsg(batchId : String, override val r2Id : Int, error: String, listener : ActorRef) extends MigrationResult(r2Id){
@@ -126,7 +124,8 @@ protected[batch] object AkkaBatchMigratorMessages{
 
 
 protected[batch] class AkkaBatchMigratorOrchestrator(migrationBehaviour : MigrationBehaviour,
-                                    batchId : String, size  : Int, batchNumber : Int, tagIds : Option[String]) extends Actor {
+                                    batchId : String, size  : Int, batchNumber : Int,
+                                    tagIds : Option[String], withIdsHigherThan : Option[Int]) extends Actor {
 
 
   import AkkaBatchMigratorMessages._
@@ -179,7 +178,7 @@ protected[batch] class AkkaBatchMigratorOrchestrator(migrationBehaviour : Migrat
   }
 
   private def sendClientResultsNow(resultsListener : ActorRef): Unit ={
-    val successVideos = results.filter(_.isSuccess).map(_.asInstanceOf[MigratedVideoResultMsg]).map(_.video)
+    val successVideos = results.filter(_.isSuccess).map(_.asInstanceOf[MigratedContentResultMsg]).map(_.content)
     val failedVideos = results.filterNot(_.isSuccess).map(_.asInstanceOf[MigrationErrorResultMsg]).map(errorMsg =>
       MigrationFailedContent(errorMsg.r2Id, errorMsg.error))
     if(results.size == size){
@@ -206,7 +205,7 @@ protected[batch] class AkkaBatchMigratorOrchestrator(migrationBehaviour : Migrat
   private def startMigration(resultsListener : ActorRef) = {
     //TODO: prevent future start requests coming in!
     Logger.debug(s"startMigration")
-    val contentIds: Future[List[Int]] = migrationBehaviour.contentLoader.getBatchOfContentIds(size, batchNumber, tagIds)
+    val contentIds: Future[List[Int]] = migrationBehaviour.contentLoader.getBatchOfContentIds(size, batchNumber, tagIds, withIdsHigherThan)
     contentIds.onSuccess[Unit]{
       case ids : List[Int] => idsInCurrentBatch = ids
     }
@@ -237,19 +236,19 @@ protected[batch] class AkkaBatchMigratorR2Loader(r2MigrationService : R2Migratio
     case loadVideoMsg: LoadContentR2Msg => loadR2Content(loadVideoMsg, loadVideoMsg.resultsListener)
   }
 
-  private def loadR2Content(loadVideoR2 : LoadContentR2Msg, resultsListener : ActorRef){
-    Logger.debug(s"loadR2Content ${loadVideoR2.contentId}")
+  private def loadR2Content(loadContentR2 : LoadContentR2Msg, resultsListener : ActorRef){
+    Logger.debug(s"loadR2Content ${loadContentR2.contentId}")
     try{
-      val loadedVideo =
-        r2MigrationService.loadContentById(loadVideoR2.contentId)
-      loadedVideo.map(srcVideo =>
-        nextInChain ! TransformContentMsg(batchId, srcVideo, resultsListener)
+      val loadedContent =
+        r2MigrationService.loadContentById(loadContentR2.contentId)
+      loadedContent.map(srcContent =>
+        nextInChain ! TransformContentMsg(batchId, srcContent, resultsListener)
       ).recover{
-        case e: Exception => sendErrorMsg(loadVideoR2.contentId, "Failed to load content from r2: " + e.toString, resultsListener, Some(e))
+        case e: Exception => sendErrorMsg(loadContentR2.contentId, "Failed to load content from r2: " + e.toString, resultsListener, Some(e))
       }
     }
     catch{
-      case e : Exception => sendErrorMsg(loadVideoR2.contentId, "Failed to load content from r2: " + e.toString, resultsListener, Some(e))
+      case e : Exception => sendErrorMsg(loadContentR2.contentId, "Failed to load content from r2: " + e.toString, resultsListener, Some(e))
     }
   }
 }
@@ -317,7 +316,7 @@ protected[batch] class AkkaBatchMigratorMigrateInR2(migrateVideoInR2 : MigrateCo
       migrateVideoInR2(migrate.content).map{ result =>
         result match {
           case ok: MigratedContent => {
-            orchestrator ! MigratedVideoResultMsg(batchId, ok, resultsListener)
+            orchestrator ! MigratedContentResultMsg(batchId, ok, resultsListener)
           }
           case problem: MigrationFailedContent => sendErrorMsg(migrate.content.id, s"Failed to migrate content in R2 : ${problem.reason}", resultsListener)
         }

--- a/app/services/migration/batch/BatchMigrator.scala
+++ b/app/services/migration/batch/BatchMigrator.scala
@@ -34,7 +34,7 @@ protected[migration] object SimpleBatchMigrator extends BatchMigrator{
       Future.sequence(contentInFlex.map(video => migrationBehaviour.closeContentInSource(video)))
 
 
-    val sourceContent = migrationBehaviour.contentLoader.loadBatchOfContent(params.batchSize, params.batchNumber, params.tagIds, params.withIdsHigherThan)
+    val sourceContent = migrationBehaviour.contentLoader.loadBatchOfContent(params)
     val videosInFlex = sourceContent.flatMap(pushContentInFlex(_))
     val videosInR2 = videosInFlex.flatMap(migrateContentsInR2(_))
     videosInR2.map{ results => {
@@ -203,7 +203,7 @@ protected[batch] class AkkaBatchMigratorOrchestrator(migrationBehaviour : Migrat
   private def startMigration(resultsListener : ActorRef) = {
     //TODO: prevent future start requests coming in!
     Logger.debug(s"startMigration")
-    val contentIds: Future[List[Int]] = migrationBehaviour.contentLoader.getBatchOfContentIds(params.batchSize, params.batchNumber, params.tagIds, params.withIdsHigherThan)
+    val contentIds: Future[List[Int]] = migrationBehaviour.contentLoader.getBatchOfContentIds(params)
     contentIds.onSuccess[Unit]{
       case ids : List[Int] => idsInCurrentBatch = ids
     }

--- a/app/services/migration/r2/R2AritcleMigrationService.scala
+++ b/app/services/migration/r2/R2AritcleMigrationService.scala
@@ -21,18 +21,18 @@ abstract class R2ArticleMigratorService(client : R2IntegrationAPIClient) extends
   def loadContentById(id : Integer) = loadContentWithThrottle(id)
 
 
-  override def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String]) =
-    client.getBatchOfArticleIds(batchSize, batchOffset, tagIds)
+  override def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String], withIdsHigherThan : Option[Int]) =
+    client.getBatchOfArticleIds(batchSize, batchOffset, tagIds, withIdsHigherThan)
 
 
-  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None) : Future[MigrationBatch] = {
+  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None, withIdsHigherThan : Option[Int] = None) : Future[MigrationBatch] = {
     def mapIdsToArticles(ids: Future[List[Int]]) = {
       def idsToArticles(ids : List[Int]) = ids.map(loadContentWithThrottle(_))
 
       ids.map{idsToArticles(_)}.flatMap(Future.sequence(_))
     }
 
-    val ids = client.getBatchOfArticleIds(batchSize, batchNumber, tagIds)
+    val ids = client.getBatchOfArticleIds(batchSize, batchNumber, tagIds, withIdsHigherThan)
     val audios = mapIdsToArticles(ids)
     audios.map(loadedArticles => {
       Logger.info(s"Loaded the batch of ${batchSize} articles from R2")

--- a/app/services/migration/r2/R2AritcleMigrationService.scala
+++ b/app/services/migration/r2/R2AritcleMigrationService.scala
@@ -2,7 +2,7 @@ package services.migration.r2
 
 import model.{MigrationBatch, SourceContent}
 import play.Logger
-import services.migration.ThrottleControl
+import services.migration.{MigrationBatchParams, ThrottleControl}
 
 import scala.concurrent.Future
 
@@ -21,21 +21,21 @@ abstract class R2ArticleMigratorService(client : R2IntegrationAPIClient) extends
   def loadContentById(id : Integer) = loadContentWithThrottle(id)
 
 
-  override def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String], withIdsHigherThan : Option[Int]) =
-    client.getBatchOfArticleIds(batchSize, batchOffset, tagIds, withIdsHigherThan)
+  override def getBatchOfContentIds(params : MigrationBatchParams) =
+    client.getBatchOfArticleIds(params)
 
 
-  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None, withIdsHigherThan : Option[Int] = None) : Future[MigrationBatch] = {
+  def loadBatchOfContent(params : MigrationBatchParams) : Future[MigrationBatch] = {
     def mapIdsToArticles(ids: Future[List[Int]]) = {
       def idsToArticles(ids : List[Int]) = ids.map(loadContentWithThrottle(_))
 
       ids.map{idsToArticles(_)}.flatMap(Future.sequence(_))
     }
 
-    val ids = client.getBatchOfArticleIds(batchSize, batchNumber, tagIds, withIdsHigherThan)
+    val ids = client.getBatchOfArticleIds(params)
     val audios = mapIdsToArticles(ids)
     audios.map(loadedArticles => {
-      Logger.info(s"Loaded the batch of ${batchSize} articles from R2")
+      Logger.info(s"Loaded the batch of ${params.batchSize} articles from R2")
       new MigrationBatch(loadedArticles)
     })
   }

--- a/app/services/migration/r2/R2AudioMigrationService.scala
+++ b/app/services/migration/r2/R2AudioMigrationService.scala
@@ -21,18 +21,20 @@ abstract class R2AudioMigratorService(client : R2IntegrationAPIClient) extends R
   def loadContentById(id : Integer) = loadContentWithThrottle(id)
 
 
-  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String]) = {
-    if (tagIds.isDefined) throw new UnsupportedOperationException("Tag specific migration not supported for audios")
+  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String] = None, idsHigherThan : Option[Int] = None) = {
+    assert(tagIds.isEmpty) //not supported
+    assert(idsHigherThan.isEmpty) //not supported
+
     client.getBatchOfAudioIds(batchSize, batchOffset)
   }
 
-  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String]) : Future[MigrationBatch] = {
+  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None, idsHigherThan : Option[Int] = None) : Future[MigrationBatch] = {
     def mapIdsToAudios(ids: Future[List[Int]]) = {
       def idsToAudios(ids : List[Int]) = ids.map(loadContentWithThrottle(_))
 
       ids.map{idsToAudios(_)}.flatMap(Future.sequence(_))
     }
-    val ids = client.getBatchOfAudioIds(batchSize, batchNumber, tagIds)
+    val ids = client.getBatchOfAudioIds(batchSize, batchNumber, tagIds, idsHigherThan)
     val audios = mapIdsToAudios(ids)
     audios.map(loadedAudios => {
       Logger.info(s"Loaded the batch of ${batchSize} audios from R2")

--- a/app/services/migration/r2/R2CartoonMigrationService.scala
+++ b/app/services/migration/r2/R2CartoonMigrationService.scala
@@ -2,7 +2,7 @@ package services.migration.r2
 
 import model.{MigrationBatch, SourceContent}
 import play.Logger
-import services.migration.ThrottleControl
+import services.migration.{MigrationBatchParams, ThrottleControl}
 
 import scala.concurrent.Future
 
@@ -21,20 +21,20 @@ abstract class R2CartoonMigratorService(client : R2IntegrationAPIClient) extends
   def loadContentById(id : Integer) = loadContentWithThrottle(id)
 
 
-  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String] = None, idsHigherThan : Option[Int] = None) =
-    client.getBatchOfCartoonIds(batchSize, batchOffset, tagIds, idsHigherThan)
+  def getBatchOfContentIds(params : MigrationBatchParams) =
+    client.getBatchOfCartoonIds(params)
 
-  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None, idsHigherThan : Option[Int] = None) : Future[MigrationBatch] = {
+  def loadBatchOfContent(params : MigrationBatchParams) : Future[MigrationBatch] = {
     def mapIdsToCartoons(ids: Future[List[Int]]) = {
       def idsToCartoons(ids : List[Int]) = ids.map(loadContentWithThrottle(_))
 
       ids.map{idsToCartoons(_)}.flatMap(Future.sequence(_))
     }
 
-    val ids = client.getBatchOfCartoonIds(batchSize, batchNumber, tagIds, idsHigherThan)
+    val ids = client.getBatchOfCartoonIds(params)
     val cartoons = mapIdsToCartoons(ids)
     cartoons.map(loadedCartoons => {
-      Logger.info(s"Loaded the batch of ${batchSize} cartoons from R2")
+      Logger.info(s"Loaded the batch of ${params.batchSize} cartoons from R2")
       new MigrationBatch(loadedCartoons)
     })
   }

--- a/app/services/migration/r2/R2CartoonMigrationService.scala
+++ b/app/services/migration/r2/R2CartoonMigrationService.scala
@@ -21,17 +21,17 @@ abstract class R2CartoonMigratorService(client : R2IntegrationAPIClient) extends
   def loadContentById(id : Integer) = loadContentWithThrottle(id)
 
 
-  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String] = None) =
-    client.getBatchOfCartoonIds(batchSize, batchOffset, tagIds)
+  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String] = None, idsHigherThan : Option[Int] = None) =
+    client.getBatchOfCartoonIds(batchSize, batchOffset, tagIds, idsHigherThan)
 
-  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None) : Future[MigrationBatch] = {
+  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None, idsHigherThan : Option[Int] = None) : Future[MigrationBatch] = {
     def mapIdsToCartoons(ids: Future[List[Int]]) = {
       def idsToCartoons(ids : List[Int]) = ids.map(loadContentWithThrottle(_))
 
       ids.map{idsToCartoons(_)}.flatMap(Future.sequence(_))
     }
 
-    val ids = client.getBatchOfCartoonIds(batchSize, batchNumber, tagIds)
+    val ids = client.getBatchOfCartoonIds(batchSize, batchNumber, tagIds, idsHigherThan)
     val cartoons = mapIdsToCartoons(ids)
     cartoons.map(loadedCartoons => {
       Logger.info(s"Loaded the batch of ${batchSize} cartoons from R2")

--- a/app/services/migration/r2/R2GalleryMigrationService.scala
+++ b/app/services/migration/r2/R2GalleryMigrationService.scala
@@ -21,17 +21,17 @@ abstract class R2GalleryMigratorService(client : R2IntegrationAPIClient) extends
   def loadContentById(id : Integer) = loadContentWithThrottle(id)
 
 
-  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String] = None) =
-    client.getBatchOfGalleryIds(batchSize, batchOffset, tagIds)
+  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String] = None, idsHigherThan : Option[Int] = None) =
+    client.getBatchOfGalleryIds(batchSize, batchOffset, tagIds, idsHigherThan)
 
-  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None) : Future[MigrationBatch] = {
+  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None, idsHigherThan : Option[Int] = None) : Future[MigrationBatch] = {
     def mapIdsToGalleries(ids: Future[List[Int]]) = {
       def idsToGalleries(ids : List[Int]) = ids.map(loadContentWithThrottle(_))
 
       ids.map{idsToGalleries(_)}.flatMap(Future.sequence(_))
     }
 
-    val ids = client.getBatchOfGalleryIds(batchSize, batchNumber, tagIds)
+    val ids = client.getBatchOfGalleryIds(batchSize, batchNumber, tagIds, idsHigherThan)
     val galleries = mapIdsToGalleries(ids)
     galleries.map(loadedGalleries => {
       Logger.info(s"Loaded the batch of ${batchSize} galleries from R2")

--- a/app/services/migration/r2/R2GalleryMigrationService.scala
+++ b/app/services/migration/r2/R2GalleryMigrationService.scala
@@ -2,7 +2,7 @@ package services.migration.r2
 
 import model.{MigrationBatch, SourceContent}
 import play.Logger
-import services.migration.ThrottleControl
+import services.migration.{MigrationBatchParams, ThrottleControl}
 
 import scala.concurrent.Future
 
@@ -21,20 +21,20 @@ abstract class R2GalleryMigratorService(client : R2IntegrationAPIClient) extends
   def loadContentById(id : Integer) = loadContentWithThrottle(id)
 
 
-  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String] = None, idsHigherThan : Option[Int] = None) =
-    client.getBatchOfGalleryIds(batchSize, batchOffset, tagIds, idsHigherThan)
+  def getBatchOfContentIds(params : MigrationBatchParams) =
+    client.getBatchOfGalleryIds(params)
 
-  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None, idsHigherThan : Option[Int] = None) : Future[MigrationBatch] = {
+  def loadBatchOfContent(params : MigrationBatchParams) : Future[MigrationBatch] = {
     def mapIdsToGalleries(ids: Future[List[Int]]) = {
       def idsToGalleries(ids : List[Int]) = ids.map(loadContentWithThrottle(_))
 
       ids.map{idsToGalleries(_)}.flatMap(Future.sequence(_))
     }
 
-    val ids = client.getBatchOfGalleryIds(batchSize, batchNumber, tagIds, idsHigherThan)
+    val ids = client.getBatchOfGalleryIds(params)
     val galleries = mapIdsToGalleries(ids)
     galleries.map(loadedGalleries => {
-      Logger.info(s"Loaded the batch of ${batchSize} galleries from R2")
+      Logger.info(s"Loaded the batch of ${params.batchSize} galleries from R2")
       new MigrationBatch(loadedGalleries)
     })
   }

--- a/app/services/migration/r2/R2IntegrationAPIClient.scala
+++ b/app/services/migration/r2/R2IntegrationAPIClient.scala
@@ -143,38 +143,42 @@ protected[migration] class R2IntegrationAPIClient {
   
 
 
-  protected[migration] def getBatchOfGalleryIds(batchSize : Int, batchNumber : Int, tagIds : Option[String]=None) : Future[List[Int]] = {
+  protected[migration] def getBatchOfGalleryIds(batchSize : Int, batchNumber : Int, tagIds : Option[String]=None, idHigherThan : Option[Int] = None) : Future[List[Int]] = {
     if(tagIds.isDefined) throw new UnsupportedOperationException("Specific tagId migration not supported for galleries")
+    if(idHigherThan.isDefined) throw new UnsupportedOperationException("idHigherThan is not supported for galleries")
     WS.url(requestGalleriesToMigrate(batchSize, batchNumber)).get().map{response =>
       (response.json \ "elementsOnCurrentPage").as[List[Int]]
     }
   }
 
-  protected[migration] def getBatchOfCartoonIds(batchSize : Int, batchNumber : Int, tagIds : Option[String]=None) : Future[List[Int]] = {
+  protected[migration] def getBatchOfCartoonIds(batchSize : Int, batchNumber : Int, tagIds : Option[String]=None, idHigherThan : Option[Int] = None ) : Future[List[Int]] = {
     if(tagIds.isDefined) throw new UnsupportedOperationException("Specific tagId migration not supported for cartoons")
+    if(idHigherThan.isDefined) throw new UnsupportedOperationException("idHigherThan is not supported for cartoons")
     WS.url(requestCartoonsToMigrate(batchSize, batchNumber)).get().map{response =>
       (response.json \ "elementsOnCurrentPage").as[List[Int]]
     }
   }
 
-  protected[migration] def getBatchOfQuizIds(batchSize : Int, batchNumber : Int, tagIds : Option[String]=None) : Future[List[Int]] = {
+  protected[migration] def getBatchOfQuizIds(batchSize : Int, batchNumber : Int, tagIds : Option[String]=None, idHigherThan : Option[Int] = None) : Future[List[Int]] = {
     if(tagIds.isDefined) throw new UnsupportedOperationException("Specific tagId migration not supported for quizzes")
+    if(idHigherThan.isDefined) throw new UnsupportedOperationException("idHigherThan is not supported for quizzes")
     WS.url(requestQuizzesToMigrate(batchSize, batchNumber)).get().map{response =>
       (response.json \ "elementsOnCurrentPage").as[List[Int]]
     }
   }
 
-  protected[migration] def getBatchOfAudioIds(batchSize : Int, batchNumber : Int, tagIds : Option[String]=None) : Future[List[Int]] = {
+  protected[migration] def getBatchOfAudioIds(batchSize : Int, batchNumber : Int, tagIds : Option[String]=None, idHigherThan : Option[Int] = None) : Future[List[Int]] = {
     if(tagIds.isDefined) throw new UnsupportedOperationException("Specific tagId migration not supported for audios")
+    if(idHigherThan.isDefined) throw new UnsupportedOperationException("idHigherThan is not supported for audios")
     WS.url(requestAudiosToMigrate(batchSize, batchNumber)).get().map{response =>
       (response.json \ "elementsOnCurrentPage").as[List[Int]]
     }
   }
 
 
-  protected[migration] def getBatchOfArticleIds(batchSize : Int, batchNumber : Int, tagIds : Option[String]) : Future[List[Int]] = {
-    Logger.debug(s"Loading articles : batchSize=${batchSize} batchNumber=${batchNumber} tagIds=${tagIds}")
-    WS.url(requestArticlesToMigrate(batchSize, batchNumber, tagIds)).get().map{response =>
+  protected[migration] def getBatchOfArticleIds(batchSize : Int, batchNumber : Int, tagIds : Option[String], withIdsHigherThan : Option[Int]) : Future[List[Int]] = {
+    Logger.debug(s"Loading articles : batchSize=${batchSize} batchNumber=${batchNumber} tagIds=${tagIds} withIdsHigherThan]${withIdsHigherThan}")
+    WS.url(requestArticlesToMigrate(batchSize, batchNumber, tagIds, withIdsHigherThan)).get().map{response =>
       (response.json \ "elementsOnCurrentPage").as[List[Int]]
     }
   }
@@ -230,8 +234,9 @@ protected[migration] class R2IntegrationAPIClient {
 
   private def pageNumber(offset : Int) = s"pageNumber=${offset}"
 
-  private def tags(tagIds : Option[String]) =
-    tagIds.map("&tagIds=" + _).getOrElse("")
+  private def idHigherThan(idHigherThan : Option[Int]) = idHigherThan.map("&idHigherThan=" + _).getOrElse("")
+
+  private def tags(tagIds : Option[String]) = tagIds.map("&tagIds=" + _).getOrElse("")
 
   private def r2ContentId(id : Int) = s"r2ContentId=${id}"
 
@@ -250,8 +255,8 @@ protected[migration] class R2IntegrationAPIClient {
   private def requestAudiosToMigrate(size : Int, offset : Int) =
     s"${AudiosToMigrateUrl}?${pageSize(size)}&${pageNumber(offset)}"
 
-  private def requestArticlesToMigrate(size : Int, offset : Int, tagIds : Option[String]) =
-    s"${ArticlesToMigrateUrl}?${pageSize(size)}&${pageNumber(offset)}${tags(tagIds)}"
+  private def requestArticlesToMigrate(size : Int, offset : Int, tagIds : Option[String], withIdsHigherThan : Option[Int]) =
+    s"${ArticlesToMigrateUrl}?${pageSize(size)}&${pageNumber(offset)}${tags(tagIds)}${idHigherThan(withIdsHigherThan)}"
 
   private def requestContentMigrated(r2ContentIdInt : Int, composerIdSt : String) =
     s"${ContentMigratedUrl}?${r2ContentId(r2ContentIdInt)}&${composerId(composerIdSt)}"
@@ -263,8 +268,8 @@ trait R2MigrationService{
 
   def loadContentById(id : Integer) : Future[SourceContent]
 
-  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String]) : Future[MigrationBatch]
-  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String]) : Future[List[Int]]
+  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String], withIdsHigherThan : Option[Int]) : Future[MigrationBatch]
+  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String], withIdsHigherThan : Option[Int]) : Future[List[Int]]
 
   def migrateContentInR2(contentId : Int, composerId : String) : Future[(Boolean, String)]
 

--- a/app/services/migration/r2/R2IntegrationAPIClient.scala
+++ b/app/services/migration/r2/R2IntegrationAPIClient.scala
@@ -7,6 +7,7 @@ import play.api.Play
 import play.api.Play.current
 import play.api.libs.ws.{WS, WSResponse}
 import services.aws.Metrics
+import services.migration.MigrationBatchParams
 
 import scala.concurrent.Future
 
@@ -143,42 +144,42 @@ protected[migration] class R2IntegrationAPIClient {
   
 
 
-  protected[migration] def getBatchOfGalleryIds(batchSize : Int, batchNumber : Int, tagIds : Option[String]=None, idHigherThan : Option[Int] = None) : Future[List[Int]] = {
-    if(tagIds.isDefined) throw new UnsupportedOperationException("Specific tagId migration not supported for galleries")
-    if(idHigherThan.isDefined) throw new UnsupportedOperationException("idHigherThan is not supported for galleries")
-    WS.url(requestGalleriesToMigrate(batchSize, batchNumber)).get().map{response =>
+  protected[migration] def getBatchOfGalleryIds(params : MigrationBatchParams) : Future[List[Int]] = {
+    if(params.tagIds.isDefined) throw new UnsupportedOperationException("Specific tagId migration not supported for galleries")
+    if(params.withIdsHigherThan.isDefined) throw new UnsupportedOperationException("idHigherThan is not supported for galleries")
+    WS.url(requestGalleriesToMigrate(params.batchSize, params.batchNumber)).get().map{response =>
       (response.json \ "elementsOnCurrentPage").as[List[Int]]
     }
   }
 
-  protected[migration] def getBatchOfCartoonIds(batchSize : Int, batchNumber : Int, tagIds : Option[String]=None, idHigherThan : Option[Int] = None ) : Future[List[Int]] = {
-    if(tagIds.isDefined) throw new UnsupportedOperationException("Specific tagId migration not supported for cartoons")
-    if(idHigherThan.isDefined) throw new UnsupportedOperationException("idHigherThan is not supported for cartoons")
-    WS.url(requestCartoonsToMigrate(batchSize, batchNumber)).get().map{response =>
+  protected[migration] def getBatchOfCartoonIds(params : MigrationBatchParams ) : Future[List[Int]] = {
+    if(params.tagIds.isDefined) throw new UnsupportedOperationException("Specific tagId migration not supported for cartoons")
+    if(params.withIdsHigherThan.isDefined) throw new UnsupportedOperationException("idHigherThan is not supported for cartoons")
+    WS.url(requestCartoonsToMigrate(params.batchSize, params.batchNumber)).get().map{response =>
       (response.json \ "elementsOnCurrentPage").as[List[Int]]
     }
   }
 
-  protected[migration] def getBatchOfQuizIds(batchSize : Int, batchNumber : Int, tagIds : Option[String]=None, idHigherThan : Option[Int] = None) : Future[List[Int]] = {
-    if(tagIds.isDefined) throw new UnsupportedOperationException("Specific tagId migration not supported for quizzes")
-    if(idHigherThan.isDefined) throw new UnsupportedOperationException("idHigherThan is not supported for quizzes")
-    WS.url(requestQuizzesToMigrate(batchSize, batchNumber)).get().map{response =>
+  protected[migration] def getBatchOfQuizIds(params : MigrationBatchParams) : Future[List[Int]] = {
+    if(params.tagIds.isDefined) throw new UnsupportedOperationException("Specific tagId migration not supported for quizzes")
+    if(params.withIdsHigherThan.isDefined) throw new UnsupportedOperationException("idHigherThan is not supported for quizzes")
+    WS.url(requestQuizzesToMigrate(params.batchSize, params.batchNumber)).get().map{response =>
       (response.json \ "elementsOnCurrentPage").as[List[Int]]
     }
   }
 
-  protected[migration] def getBatchOfAudioIds(batchSize : Int, batchNumber : Int, tagIds : Option[String]=None, idHigherThan : Option[Int] = None) : Future[List[Int]] = {
-    if(tagIds.isDefined) throw new UnsupportedOperationException("Specific tagId migration not supported for audios")
-    if(idHigherThan.isDefined) throw new UnsupportedOperationException("idHigherThan is not supported for audios")
-    WS.url(requestAudiosToMigrate(batchSize, batchNumber)).get().map{response =>
+  protected[migration] def getBatchOfAudioIds(params : MigrationBatchParams) : Future[List[Int]] = {
+    if(params.tagIds.isDefined) throw new UnsupportedOperationException("Specific tagId migration not supported for audios")
+    if(params.withIdsHigherThan.isDefined) throw new UnsupportedOperationException("idHigherThan is not supported for audios")
+    WS.url(requestAudiosToMigrate(params.batchSize, params.batchNumber)).get().map{response =>
       (response.json \ "elementsOnCurrentPage").as[List[Int]]
     }
   }
 
 
-  protected[migration] def getBatchOfArticleIds(batchSize : Int, batchNumber : Int, tagIds : Option[String], withIdsHigherThan : Option[Int]) : Future[List[Int]] = {
-    Logger.debug(s"Loading articles : batchSize=${batchSize} batchNumber=${batchNumber} tagIds=${tagIds} withIdsHigherThan]${withIdsHigherThan}")
-    WS.url(requestArticlesToMigrate(batchSize, batchNumber, tagIds, withIdsHigherThan)).get().map{response =>
+  protected[migration] def getBatchOfArticleIds(params : MigrationBatchParams) : Future[List[Int]] = {
+    Logger.info(s"Loading articles : batchSize=${params.batchSize} batchNumber=${params.batchNumber} tagIds=${params.tagIds} withIdsHigherThan]${params.withIdsHigherThan}")
+    WS.url(requestArticlesToMigrate(params.batchSize, params.batchNumber, params.tagIds, params.withIdsHigherThan)).get().map{response =>
       (response.json \ "elementsOnCurrentPage").as[List[Int]]
     }
   }
@@ -268,8 +269,8 @@ trait R2MigrationService{
 
   def loadContentById(id : Integer) : Future[SourceContent]
 
-  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String], withIdsHigherThan : Option[Int]) : Future[MigrationBatch]
-  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String], withIdsHigherThan : Option[Int]) : Future[List[Int]]
+  def loadBatchOfContent(params : MigrationBatchParams) : Future[MigrationBatch]
+  def getBatchOfContentIds(params : MigrationBatchParams) : Future[List[Int]]
 
   def migrateContentInR2(contentId : Int, composerId : String) : Future[(Boolean, String)]
 

--- a/app/services/migration/r2/R2QuizMigrationService.scala
+++ b/app/services/migration/r2/R2QuizMigrationService.scala
@@ -20,11 +20,11 @@ abstract class R2QuizMigratorService(client : R2IntegrationAPIClient) extends R2
 
   def loadContentById(id : Integer) = loadContentWithThrottle(id)
 
-  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String] = None) ={
+  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String] = None, idsHigherThan : Option[Int]) ={
     client.getBatchOfQuizIds(batchSize, batchOffset, tagIds)
   }
 
-  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None) : Future[MigrationBatch] = {
+  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None, idsHigherThan : Option[Int]) : Future[MigrationBatch] = {
     def mapIdsToQuizzes(ids: Future[List[Int]]) = {
       def idsToQuizzes(ids : List[Int]) = ids.map(loadContentWithThrottle(_))
 

--- a/app/services/migration/r2/R2QuizMigrationService.scala
+++ b/app/services/migration/r2/R2QuizMigrationService.scala
@@ -2,7 +2,7 @@ package services.migration.r2
 
 import model.{MigrationBatch, SourceContent}
 import play.Logger
-import services.migration.ThrottleControl
+import services.migration.{MigrationBatchParams, ThrottleControl}
 
 import scala.concurrent.Future
 
@@ -20,21 +20,21 @@ abstract class R2QuizMigratorService(client : R2IntegrationAPIClient) extends R2
 
   def loadContentById(id : Integer) = loadContentWithThrottle(id)
 
-  def getBatchOfContentIds(batchSize : Int, batchOffset : Int, tagIds : Option[String] = None, idsHigherThan : Option[Int]) ={
-    client.getBatchOfQuizIds(batchSize, batchOffset, tagIds)
+  def getBatchOfContentIds(params : MigrationBatchParams) ={
+    client.getBatchOfQuizIds(params)
   }
 
-  def loadBatchOfContent(batchSize : Int, batchNumber : Int = 1, tagIds : Option[String] = None, idsHigherThan : Option[Int]) : Future[MigrationBatch] = {
+  def loadBatchOfContent(params : MigrationBatchParams) : Future[MigrationBatch] = {
     def mapIdsToQuizzes(ids: Future[List[Int]]) = {
       def idsToQuizzes(ids : List[Int]) = ids.map(loadContentWithThrottle(_))
 
       ids.map{idsToQuizzes(_)}.flatMap(Future.sequence(_))
     }
 
-    val ids = client.getBatchOfGalleryIds(batchSize, batchNumber, tagIds)
+    val ids = client.getBatchOfGalleryIds(params)
     val quizzes = mapIdsToQuizzes(ids)
     quizzes.map(loadedQuizzes => {
-      Logger.info(s"Loaded the batch of ${batchSize} quizzes from R2")
+      Logger.info(s"Loaded the batch of ${params.batchSize} quizzes from R2")
       new MigrationBatch(loadedQuizzes)
     })
   }

--- a/conf/routes
+++ b/conf/routes
@@ -24,7 +24,7 @@ POST        /migrate/audio/:audio_id         controllers.migration.AudioMigratio
 
 GET         /article                         controllers.migration.ArticleMigrationApi.articlePage
 GET         /check/article                   controllers.migration.ArticleMigrationApi.checkFlexConnection
-POST        /migrate/article                 controllers.migration.ArticleMigrationApi.migrateBatch(batchSize: Option[Int] ?=None, batchNumber : Option[Int] ?=None, tagIds : Option[String] ?=None)
+POST        /migrate/article                 controllers.migration.ArticleMigrationApi.migrateBatch(batchSize: Option[Int] ?=None, batchNumber : Option[Int] ?=None, tagIds : Option[String] ?=None, withIdsHigherThan : Option[Int] ?=None)
 POST        /migrate/article/:article_id     controllers.migration.ArticleMigrationApi.migrateArticle(article_id : Int)
 POST        /migrate/article/json/:article_id     controllers.migration.ArticleMigrationApi.migrateArticleJson(article_id : Int)
 

--- a/runMigrationScriptAWS_LOCAL_randomise.sh
+++ b/runMigrationScriptAWS_LOCAL_randomise.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+echo off
+
+
+#PROD
+
+BATCH_SIZE=${BATCH_SIZE:-15}                    # NO BIGGER THAN 30
+NUMBER_OF_BATCHES=${NUMBER_OF_BATCHES:-200}
+#TAGIDS=${TAGIDS:-6964}  #MARKET FORCES
+RANDOM_FACTOR=${RANDOM_FACTOR:-200}                #Increase this value to migrate more randomly
+SLEEP_TIME=${SLEEP_TIME:-1}
+MIN_BATCH_NUMBER=${MIN_BATCH_NUMBER:-1}
+
+PREFIX="http://localhost:9000/migrate/article?batchSize=$BATCH_SIZE"
+
+echo PARMS: BATCH_SIZE=$BATCH_SIZE NUMBER_OF_BATCHES=$NUMBER_OF_BATCHES RANDOM_FACTOR=$RANDOM_FACTOR SLEEP_TIME=$SLEEP_TIME MIN_BATCH_NUMBER=$MIN_BATCH_NUMBER
+read -p "Press [Enter] key to start **PROD** migration (random sequence)..."
+
+
+echo "Migrating content to $PREFIX"
+
+TIMESTAMP="$(date +"%s")"
+OUTPUT_PATH=~/.migration/output/PROD/$TIMESTAMP
+mkdir -p $OUTPUT_PATH
+echo "Results in $OUTPUT_PATH"
+
+#Perform the migration batches and collect the results
+
+ for i in `seq 1 $NUMBER_OF_BATCHES`;
+        do
+	    RANDOM_NUMBER=$(( ( RANDOM % $RANDOM_FACTOR )  + $MIN_BATCH_NUMBER ))
+	    URL="$PREFIX&batchNumber=$RANDOM_NUMBER"
+
+            echo migrating batch $i with $BATCH_SIZE content items : $URL
+            BATCH_RESULTS=$OUTPUT_PATH/batch$i.txt
+            curl -X POST $URL > $BATCH_RESULTS
+            echo "results for batch $i in $BATCH_RESULTS"
+            sleep $SLEEP_TIME
+        done
+
+
+#Analyse the files to see if any had failures
+EXPECTED_BATCH_RESULT="Batch Success Articles = $BATCH_SIZE, Failed Articles = 0"
+echo ""
+echo "Problem batches..."
+
+grep -L "$EXPECTED_BATCH_RESULT" $OUTPUT_PATH/batch*.txt

--- a/runMigrationScriptPROD_randomise.sh
+++ b/runMigrationScriptPROD_randomise.sh
@@ -4,16 +4,16 @@ echo off
 
 #PROD
 
-BATCH_SIZE=${BATCH_SIZE:-30}                    # NO BIGGER THAN 30
+BATCH_SIZE=${BATCH_SIZE:-15}                    # NO BIGGER THAN 30
 NUMBER_OF_BATCHES=${NUMBER_OF_BATCHES:-200}
-TAGIDS=${TAGIDS:-6964}  #MARKET FORCES
-RANDOM_FACTOR=${RANDOM_FACTOR:-5}                #Increase this value to migrate more randomly
+#TAGIDS=${TAGIDS:-6964}  #MARKET FORCES
+RANDOM_FACTOR=${RANDOM_FACTOR:-200}                #Increase this value to migrate more randomly
 SLEEP_TIME=${SLEEP_TIME:-1}
 MIN_BATCH_NUMBER=${MIN_BATCH_NUMBER:-1}
 
-PREFIX="http://flexcontentmigrator.gutools.co.uk/migrate/article?tagIds=$TAGIDS&batchSize=$BATCH_SIZE"
+PREFIX="http://flexcontentmigrator.gutools.co.uk/migrate/article?batchSize=$BATCH_SIZE"
 
-
+echo PARMS: BATCH_SIZE=$BATCH_SIZE NUMBER_OF_BATCHES=$NUMBER_OF_BATCHES RANDOM_FACTOR=$RANDOM_FACTOR SLEEP_TIME=$SLEEP_TIME MIN_BATCH_NUMBER=$MIN_BATCH_NUMBER
 read -p "Press [Enter] key to start **PROD** migration (random sequence)..."
 
 

--- a/runMigrationScriptPROD_restartableSequence.sh
+++ b/runMigrationScriptPROD_restartableSequence.sh
@@ -27,7 +27,7 @@ bootstrapHighestAttemptedId(){
         echo "Warm start";
         # Bootstrap by CURLing the most recent article we manged to migrate in R2, we will start from there.
         # This means we might retry a (small) number of previously failed articles at startup.
-        LastMigrated=$(curl "http://cms.guprod.gnl/tools/newspaperintegration/migration/last-migrated?content-type=article")
+        LastMigrated=$(curl "http://cms.guprod.gnl/tools/newspaperintegration/migration/last-migrated?contentType=article")
         echo "Highest Attempted Id: $LastMigrated" > temp.txt
         setHighestAttemptedIdFromTempFile
     }

--- a/runMigrationScriptPROD_restartableSequence.sh
+++ b/runMigrationScriptPROD_restartableSequence.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+echo off
+
+#PROD
+
+## Variables
+COLD_START=false                                    # Set this true to ignore the most recently migrated article and start for the lowest articles again
+BATCH_SIZE=${BATCH_SIZE:-15}                        # NO BIGGER THAN 30
+NUMBER_OF_BATCHES=${NUMBER_OF_BATCHES:-200}
+SLEEP_TIME=${SLEEP_TIME:-1}
+PREFIX="http://flexcontentmigrator.gutools.co.uk/migrate/article?batchSize=$BATCH_SIZE"
+HIGHEST_ATTEMPTED=0                                 # This will be set later on and maintained by the script as it runs
+
+
+setHighestAttemptedIdFromTempFile(){
+    HIGHEST_ATTEMPTED=$(grep "Highest Attempted Id: " temp.txt | sed "s/^Highest Attempted Id: //" );
+    echo "HIGHEST_ATTEMPTED is now $HIGHEST_ATTEMPTED"
+}
+
+bootstrapHighestAttemptedId(){
+    if $COLD_START
+    then {
+        echo "Cold start";
+        HIGHEST_ATTEMPTED=0;
+    }
+    else {
+        echo "Warm start";
+        # Bootstrap by CURLing the most recent article we manged to migrate in R2, we will start from there.
+        # This means we might retry a (small) number of previously failed articles at startup.
+        LastMigrated=$(curl "http://cms.guprod.gnl/tools/newspaperintegration/migration/last-migrated?content-type=article")
+        echo "Highest Attempted Id: $LastMigrated" > temp.txt
+        setHighestAttemptedIdFromTempFile
+    }
+    fi;
+}
+
+bootstrapHighestAttemptedId
+echo PARMS: BATCH_SIZE=$BATCH_SIZE NUMBER_OF_BATCHES=$NUMBER_OF_BATCHES RANDOM_FACTOR=$RANDOM_FACTOR SLEEP_TIME=$SLEEP_TIME MIN_BATCH_NUMBER=$MIN_BATCH_NUMBER HIGHEST_ATTEMPTED=$HIGHEST_ATTEMPTED
+read -p "Press [Enter] key to start **PROD** migration (restartable straight sequence)..."
+
+
+echo "Migrating content to $PREFIX"
+
+TIMESTAMP="$(date +"%s")"
+OUTPUT_PATH=~/.migration/output/PROD/$TIMESTAMP
+mkdir -p $OUTPUT_PATH
+echo "Results in $OUTPUT_PATH"
+
+#Perform the migration batches and collect the results
+
+ for i in `seq 1 $NUMBER_OF_BATCHES`;
+        do
+	        URL="$PREFIX&withIdHigherThan=$HIGHEST_ATTEMPTED"
+            BATCH_RESULTS=$OUTPUT_PATH/batch$i.txt
+
+            echo migrating batch $i with $BATCH_SIZE content items : $URL
+            curl -X POST $URL > temp.txt
+            setHighestAttemptedIdFromTempFile
+
+            #copy the results somewhere useful
+            cp temp.txt $BATCH_RESULTS
+            echo "results for batch $i in $BATCH_RESULTS"
+            sleep $SLEEP_TIME
+
+        done
+
+
+#Analyse the files to see if any had failures
+EXPECTED_BATCH_RESULT="Batch Success Articles = $BATCH_SIZE, Failed Articles = 0"
+echo ""
+echo "Problem batches..."
+
+grep -L "$EXPECTED_BATCH_RESULT" $OUTPUT_PATH/batch*.txt
+
+
+
+
+
+
+
+
+

--- a/test/services/migration/GalleryMigratorSpec.scala
+++ b/test/services/migration/GalleryMigratorSpec.scala
@@ -65,7 +65,7 @@ class GalleryMigratorSpec extends Specification with Mockito {
 
   "GalleryMigrator migrateBatch" should {
     "load, transform and then migrate gallery data for all galleries" in new WithApplication{
-      val migratedBatchFuture = migrator.migrateBatchOfContent(Some(NumberOfGalleries), None)
+      val migratedBatchFuture = migrator.migrateBatchOfContent(MigrationBatchParams(Some(NumberOfGalleries), None))
       val migratedBatch = Helpers.await[MigratedBatch](migratedBatchFuture)
       migratedBatch.migrated.size must equalTo(GalleriesToMigrate.size)
       migratedBatch.failed.size must equalTo(0)

--- a/test/services/migration/GalleryMigratorSpec.scala
+++ b/test/services/migration/GalleryMigratorSpec.scala
@@ -44,7 +44,7 @@ class GalleryMigratorSpec extends Specification with Mockito {
   private def migrator : Migrator = {
     val r2GalleryMigrator = mock[R2GalleryMigratorService]
     r2GalleryMigrator.loadContentById(any[Int]) returns Future{galleries.head}
-    r2GalleryMigrator.getBatchOfContentIds(any[Int], any[Int], any[Option[String]]) returns Future{(1 to NumberOfGalleries).toList}
+    r2GalleryMigrator.getBatchOfContentIds(any[Int], any[Int], any[Option[String]], any[Option[Int]]) returns Future{(1 to NumberOfGalleries).toList}
     r2GalleryMigrator.migrateContentInR2(any[Int], any[String]) returns Future{(true, "gallery migrated in r2")}
 
     val flexGalleryMigrationService = mock[FlexContentMigrationService]

--- a/test/services/migration/GalleryMigratorSpec.scala
+++ b/test/services/migration/GalleryMigratorSpec.scala
@@ -44,7 +44,7 @@ class GalleryMigratorSpec extends Specification with Mockito {
   private def migrator : Migrator = {
     val r2GalleryMigrator = mock[R2GalleryMigratorService]
     r2GalleryMigrator.loadContentById(any[Int]) returns Future{galleries.head}
-    r2GalleryMigrator.getBatchOfContentIds(any[Int], any[Int], any[Option[String]], any[Option[Int]]) returns Future{(1 to NumberOfGalleries).toList}
+    r2GalleryMigrator.getBatchOfContentIds(any[MigrationBatchParams]) returns Future{(1 to NumberOfGalleries).toList}
     r2GalleryMigrator.migrateContentInR2(any[Int], any[String]) returns Future{(true, "gallery migrated in r2")}
 
     val flexGalleryMigrationService = mock[FlexContentMigrationService]

--- a/test/services/migration/batch/BatchMigratorSpec.scala
+++ b/test/services/migration/batch/BatchMigratorSpec.scala
@@ -22,9 +22,9 @@ class BatchMigratorSpec extends Specification with Mockito {
 
     def mockR2VideoMigrator(batchSize: Int, batchOffset : Int) : R2GalleryMigratorService = {
       val themock = mock[R2GalleryMigratorService]
-      themock.getBatchOfContentIds(eqTo(batchSize), eqTo(batchOffset), any[Option[String]], any[Option[Int]]) returns Future{(1 to batchSize).toList}
+      themock.getBatchOfContentIds(any[MigrationBatchParams]) returns Future{(1 to batchSize).toList}
       themock.loadContentById(any[Int]) returns Future{srcVideo}
-      themock.loadBatchOfContent(any[Int], any[Int], any[Option[String]], any[Option[Int]]) returns Future{ MigrationBatch({for(i <- 1 to batchSize) yield srcVideo}.toList)}
+      themock.loadBatchOfContent(any[MigrationBatchParams]) returns Future{ MigrationBatch({for(i <- 1 to batchSize) yield srcVideo}.toList)}
       themock
     }
 
@@ -74,13 +74,13 @@ class BatchMigratorSpec extends Specification with Mockito {
 
     override def mockR2VideoMigrator(batchSize: Int, batchOffset : Int) : R2GalleryMigratorService = {
       val themock = mock[R2GalleryMigratorService]
-      themock.getBatchOfContentIds(eqTo(batchSize), eqTo(batchOffset), any[Option[String]], any[Option[Int]]) returns Future{(1 to batchSize).toList}
+      themock.getBatchOfContentIds(any[MigrationBatchParams]) returns Future{(1 to batchSize).toList}
       themock.loadContentById(any[Int]) answers { m =>
         val count = counterR2.incrementAndGet()
         if(count%2==0) throw new RuntimeException("Something went BANG!")
         Future{srcVideo}
       }
-      themock.loadBatchOfContent(any[Int], any[Int], any[Option[String]], any[Option[Int]]) returns Future{ MigrationBatch({for(i <- 1 to batchSize) yield srcVideo}.toList)}
+      themock.loadBatchOfContent(any[MigrationBatchParams]) returns Future{ MigrationBatch({for(i <- 1 to batchSize) yield srcVideo}.toList)}
       themock
     }
 
@@ -102,13 +102,13 @@ class BatchMigratorSpec extends Specification with Mockito {
 
     override def mockR2VideoMigrator(batchSize: Int, batchOffset : Int) : R2GalleryMigratorService = {
       val themock = mock[R2GalleryMigratorService]
-      themock.getBatchOfContentIds(batchSize, batchOffset, any[Option[String]]) returns Future{(1 to batchSize).toList}
+      themock.getBatchOfContentIds(any[MigrationBatchParams]) returns Future{(1 to batchSize).toList}
       themock.loadContentById(any[Int]) answers { m =>
         r2ThrottlerFt[SourceContent]{
           Future{srcVideo}
         }
       }
-      themock.loadBatchOfContent(any[Int], any[Int]) returns Future{ MigrationBatch({for(i <- 1 to batchSize) yield srcVideo}.toList)}
+      themock.loadBatchOfContent(any[MigrationBatchParams]) returns Future{ MigrationBatch({for(i <- 1 to batchSize) yield srcVideo}.toList)}
       themock
     }
 
@@ -130,12 +130,12 @@ class BatchMigratorSpec extends Specification with Mockito {
 
     override def mockR2VideoMigrator(batchSize: Int, batchOffset : Int) : R2GalleryMigratorService = {
       val themock = mock[R2GalleryMigratorService]
-      themock.getBatchOfContentIds(batchSize, batchOffset, any[Option[String]]) returns Future{(1 to batchSize).toList}
+      themock.getBatchOfContentIds(any[MigrationBatchParams]) returns Future{(1 to batchSize).toList}
       themock.loadContentById(any[Int]) answers { m =>
         Thread.sleep(SleepForAges)
         Future{srcVideo}
       }
-      themock.loadBatchOfContent(any[Int], any[Int]) returns Future{ MigrationBatch({for(i <- 1 to batchSize) yield srcVideo}.toList)}
+      themock.loadBatchOfContent(any[MigrationBatchParams]) returns Future{ MigrationBatch({for(i <- 1 to batchSize) yield srcVideo}.toList)}
       themock
     }
 

--- a/test/services/migration/batch/BatchMigratorSpec.scala
+++ b/test/services/migration/batch/BatchMigratorSpec.scala
@@ -58,9 +58,9 @@ class BatchMigratorSpec extends Specification with Mockito {
         override val closeContentInSource = mockMigrateVideoInR2
       }
     }
-
+    import MigrationBatchParams._
     def doAkkaBatchMigration(batchSize : Int, batchOffset : Int) : Future[MigratedBatch] =
-      AkkaBatchMigrator.migrateBatch( buildBehaviour(batchSize, batchOffset))(batchSize, batchOffset)
+      AkkaBatchMigrator.migrateBatch( buildBehaviour(batchSize, batchOffset))(MigrationBatchParams(Some(batchSize), Some(batchOffset)))
 
 
   }
@@ -174,7 +174,7 @@ class BatchMigratorSpec extends Specification with Mockito {
 
   "SimpleBatchMigrator" should {
     def doSimpleBatchMigration(batchSize : Int, batchOffset : Int) =
-      SimpleBatchMigrator.migrateBatch( AllBehaveWell.buildBehaviour(batchSize, batchOffset))(batchSize, batchOffset)
+      SimpleBatchMigrator.migrateBatch( AllBehaveWell.buildBehaviour(batchSize, batchOffset))(MigrationBatchParams(Some(batchSize), Some(batchOffset)))
 
     "migrate a batch of 10 and get a result" in {
       val batchSize = 10

--- a/test/services/migration/batch/BatchMigratorSpec.scala
+++ b/test/services/migration/batch/BatchMigratorSpec.scala
@@ -22,9 +22,9 @@ class BatchMigratorSpec extends Specification with Mockito {
 
     def mockR2VideoMigrator(batchSize: Int, batchOffset : Int) : R2GalleryMigratorService = {
       val themock = mock[R2GalleryMigratorService]
-      themock.getBatchOfContentIds(eqTo(batchSize), eqTo(batchOffset), any[Option[String]]) returns Future{(1 to batchSize).toList}
+      themock.getBatchOfContentIds(eqTo(batchSize), eqTo(batchOffset), any[Option[String]], any[Option[Int]]) returns Future{(1 to batchSize).toList}
       themock.loadContentById(any[Int]) returns Future{srcVideo}
-      themock.loadBatchOfContent(any[Int], any[Int], any[Option[String]]) returns Future{ MigrationBatch({for(i <- 1 to batchSize) yield srcVideo}.toList)}
+      themock.loadBatchOfContent(any[Int], any[Int], any[Option[String]], any[Option[Int]]) returns Future{ MigrationBatch({for(i <- 1 to batchSize) yield srcVideo}.toList)}
       themock
     }
 
@@ -74,13 +74,13 @@ class BatchMigratorSpec extends Specification with Mockito {
 
     override def mockR2VideoMigrator(batchSize: Int, batchOffset : Int) : R2GalleryMigratorService = {
       val themock = mock[R2GalleryMigratorService]
-      themock.getBatchOfContentIds(eqTo(batchSize), eqTo(batchOffset), any[Option[String]]) returns Future{(1 to batchSize).toList}
+      themock.getBatchOfContentIds(eqTo(batchSize), eqTo(batchOffset), any[Option[String]], any[Option[Int]]) returns Future{(1 to batchSize).toList}
       themock.loadContentById(any[Int]) answers { m =>
         val count = counterR2.incrementAndGet()
         if(count%2==0) throw new RuntimeException("Something went BANG!")
         Future{srcVideo}
       }
-      themock.loadBatchOfContent(any[Int], any[Int], any[Option[String]]) returns Future{ MigrationBatch({for(i <- 1 to batchSize) yield srcVideo}.toList)}
+      themock.loadBatchOfContent(any[Int], any[Int], any[Option[String]], any[Option[Int]]) returns Future{ MigrationBatch({for(i <- 1 to batchSize) yield srcVideo}.toList)}
       themock
     }
 

--- a/test/services/migration/r2/R2GalleryMigrationServiceImplSpec.scala
+++ b/test/services/migration/r2/R2GalleryMigrationServiceImplSpec.scala
@@ -6,6 +6,7 @@ import akka.util.Timeout
 import model.MigrationBatch
 import play.api.test._
 import services.RealEndpointTest
+import services.migration.MigrationBatchParams
 
 
 class R2GalleryMigrationServiceImplSpec extends RealEndpointTest  {
@@ -19,7 +20,7 @@ class R2GalleryMigrationServiceImplSpec extends RealEndpointTest  {
 
   "R2 gallery loader service " should {
     "load a batch of galleries" in new WithApplication(app) {
-      val galleriesToLoadFuture = R2GalleryMigratorServiceImpl.loadBatchOfContent(50)
+      val galleriesToLoadFuture = R2GalleryMigratorServiceImpl.loadBatchOfContent(MigrationBatchParams(Some(50), None))
       val galleriesToLoad = Helpers.await[MigrationBatch](galleriesToLoadFuture)
       galleriesToLoad.sourceContent.size must equalTo(50)
       galleriesToLoad.sourceContent.foreach{ gallery => {


### PR DESCRIPTION
- "restartable straight sequence" mode that ensures migrates each piece of content once 
- pass highestAttemptedID back and fourth on migrations so that we do not retry the same (failed) content
- refactor of the code as there are now too many parameters on the migration call stack: encapsulated into a single object that can be passed around instead