### PR TITLE
Stop using GC2 DNS proxy and bump AMI

### DIFF
--- a/cloudformation/flex-content-migrator.json
+++ b/cloudformation/flex-content-migrator.json
@@ -443,7 +443,7 @@
       },
       "Properties": {
         "KeyName":{ "Ref":"KeyName" },
-        "ImageId": "ami-fe4c0889",
+        "ImageId": "ami-2257e551",
         "InstanceType": "t2.small",
         "SecurityGroups": [
           {
@@ -473,7 +473,6 @@
                   "Ref": "AWS::Region"
                 },
                 " || error_exit 'Failed to run cfn-init'\n",
-                "/opt/features/gnm-dns/install.sh\n",
                 "unzip -d /home/flex-content-migrator /home/flex-content-migrator/flex-content-migrator.zip \n",
                 "mkdir /home/flex-content-migrator/logs\n",
                 "chown -R flex-content-migrator /home/flex-content-migrator\n",


### PR DESCRIPTION
This stops using the DNS proxy in GC2 and also bumps the AMI to the latest version.

This is assuming that we still need this around for a while, but also happy to kill this project :)